### PR TITLE
Add transaction models

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,6 +12,8 @@ pub const HEX_CURRENCY_REGEX: &str = r"^[A-F0-9]{40}$";
 /// Length of an account id.
 pub const ACCOUNT_ID_LENGTH: usize = 20;
 
+pub const TRANSACTION_HASH_PREFIX: &str = "54584E00";
+
 /// Represents the supported cryptography algorithms.
 #[derive(Debug, PartialEq, Clone, EnumIter, Display, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,8 +12,6 @@ pub const HEX_CURRENCY_REGEX: &str = r"^[A-F0-9]{40}$";
 /// Length of an account id.
 pub const ACCOUNT_ID_LENGTH: usize = 20;
 
-pub const TRANSACTION_HASH_PREFIX: &str = "54584E00";
-
 /// Represents the supported cryptography algorithms.
 #[derive(Debug, PartialEq, Clone, EnumIter, Display, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/core/definitions/types.rs
+++ b/src/core/definitions/types.rs
@@ -832,7 +832,7 @@ mod test {
         let field_instance = FieldInstance::new(&field_info, "Generic", field_header);
         let test_field_instance = get_field_instance("Generic");
 
-        assert!(!test_field_instance.is_none());
+        assert!(test_field_instance.is_some());
 
         let test_field_instance = test_field_instance.unwrap();
 

--- a/src/core/keypairs/mod.rs
+++ b/src/core/keypairs/mod.rs
@@ -93,13 +93,12 @@ pub fn generate_seed(
     algorithm: Option<CryptoAlgorithm>,
 ) -> Result<String, XRPLAddressCodecException> {
     let mut random_bytes: [u8; SEED_LENGTH] = [0u8; SEED_LENGTH];
-    let algo: CryptoAlgorithm;
 
-    if let Some(value) = algorithm {
-        algo = value;
+    let algo: CryptoAlgorithm = if let Some(value) = algorithm {
+        value
     } else {
-        algo = CryptoAlgorithm::ED25519;
-    }
+        CryptoAlgorithm::ED25519
+    };
 
     if let Some(value) = entropy {
         random_bytes = value;

--- a/src/core/types/paths.rs
+++ b/src/core/types/paths.rs
@@ -159,31 +159,28 @@ impl TryFromParser for PathStepData {
         parser: &mut BinaryParser,
         _length: Option<usize>,
     ) -> Result<PathStepData, Self::Error> {
-        let account: Option<String>;
-        let currency: Option<String>;
-        let issuer: Option<String>;
         let data_type = parser.read_uint8()?;
 
-        if data_type & _TYPE_ACCOUNT != 0 {
+        let account: Option<String> = if data_type & _TYPE_ACCOUNT != 0 {
             let data = AccountId::from_parser(parser, None)?;
-            account = Some(data.to_string());
+            Some(data.to_string())
         } else {
-            account = None;
-        }
+            None
+        };
 
-        if data_type & _TYPE_CURRENCY != 0 {
+        let currency: Option<String> = if data_type & _TYPE_CURRENCY != 0 {
             let data = Currency::from_parser(parser, None)?;
-            currency = Some(data.to_string());
+            Some(data.to_string())
         } else {
-            currency = None;
-        }
+            None
+        };
 
-        if data_type & _TYPE_ISSUER != 0 {
+        let issuer: Option<String> = if data_type & _TYPE_ISSUER != 0 {
             let data = AccountId::from_parser(parser, None)?;
-            issuer = Some(data.to_string());
+            Some(data.to_string())
         } else {
-            issuer = None;
-        }
+            None
+        };
 
         Ok(PathStepData::new(account, currency, issuer))
     }

--- a/src/core/types/vector256.rs
+++ b/src/core/types/vector256.rs
@@ -44,16 +44,14 @@ impl TryFromParser for Vector256 {
         length: Option<usize>,
     ) -> Result<Vector256, Self::Error> {
         let mut bytes = vec![];
-        let num_bytes: usize;
-        let num_hashes: usize;
 
-        if let Some(value) = length {
-            num_bytes = value;
+        let num_bytes: usize = if let Some(value) = length {
+            value
         } else {
-            num_bytes = parser.len();
-        }
+            parser.len()
+        };
 
-        num_hashes = num_bytes / _HASH_LENGTH_BYTES;
+        let num_hashes: usize = num_bytes / _HASH_LENGTH_BYTES;
 
         for _ in 0..num_hashes {
             bytes.extend_from_slice(Hash256::from_parser(parser, None)?.as_ref());

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -76,7 +76,7 @@ pub enum RequestMethod {
 /// in the Flags field. This enum represents those options.
 ///
 /// See AccountSet flags:
-/// https://xrpl.org/accountset.html#accountset-flags
+/// `<https://xrpl.org/accountset.html#accountset-flags>`
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Display, AsRefStr)]
 pub enum AccountSetFlag {
     /// Track the ID of this account's most recent transaction
@@ -117,7 +117,7 @@ pub enum AccountSetFlag {
 /// in the Flags field. This enum represents those options.
 ///
 /// See NFTokenCreateOffer flags:
-/// https://xrpl.org/nftokencreateoffer.html#nftokencreateoffer-flags
+/// `<https://xrpl.org/nftokencreateoffer.html#nftokencreateoffer-flags>`
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Display, AsRefStr)]
 pub enum NFTokenCreateOfferFlag {
     /// If enabled, indicates that the offer is a sell offer.
@@ -129,7 +129,7 @@ pub enum NFTokenCreateOfferFlag {
 /// in the Flags field. This enum represents those options.
 ///
 /// See NFTokenMint flags:
-/// https://xrpl.org/nftokenmint.html#nftokenmint-flags
+/// `<https://xrpl.org/nftokenmint.html#nftokenmint-flags>`
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Display, AsRefStr)]
 pub enum NFTokenMintFlag {
     /// Allow the issuer (or an entity authorized by the issuer) to
@@ -151,7 +151,7 @@ pub enum NFTokenMintFlag {
 /// in the Flags field. This enum represents those options.
 ///
 /// See OfferCreate flags:
-/// https://xrpl.org/offercreate.html#offercreate-flags
+/// `<https://xrpl.org/offercreate.html#offercreate-flags>`
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Display, AsRefStr)]
 pub enum OfferCreateFlag {
     /// If enabled, the Offer does not consume Offers that exactly match it,
@@ -179,7 +179,7 @@ pub enum OfferCreateFlag {
 /// in the Flags field. This enum represents those options.
 ///
 /// See Payment flags:
-/// https://xrpl.org/payment.html#payment-flags
+/// `<https://xrpl.org/payment.html#payment-flags>`
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Display, AsRefStr)]
 pub enum PaymentFlag {
     /// Do not use the default path; only use paths included in the Paths field.
@@ -200,7 +200,7 @@ pub enum PaymentFlag {
 /// in the Flags field. This enum represents those options.
 ///
 /// See PaymentChannelClaim flags:
-/// https://xrpl.org/paymentchannelclaim.html#paymentchannelclaim-flags
+/// `<https://xrpl.org/paymentchannelclaim.html#paymentchannelclaim-flags>`
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Display, AsRefStr)]
 pub enum PaymentChannelClaimFlag {
     /// Clear the channel's Expiration time. (Expiration is different from the
@@ -224,7 +224,7 @@ pub enum PaymentChannelClaimFlag {
 /// in the Flags field. This enum represents those options.
 ///
 /// See TrustSet flags:
-/// https://xrpl.org/trustset.html#trustset-flags
+/// `<https://xrpl.org/trustset.html#trustset-flags>`
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Display, AsRefStr)]
 pub enum TrustSetFlag {
     /// Authorize the other party to hold currency issued by this account.
@@ -245,7 +245,7 @@ pub enum TrustSetFlag {
 /// in the Flags field. This enum represents those options.
 ///
 /// See EnableAmendment flags:
-/// https://xrpl.org/enableamendment.html#enableamendment-flags
+/// `<https://xrpl.org/enableamendment.html#enableamendment-flags>`
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Display, AsRefStr)]
 pub enum EnableAmendmentFlag {
     /// Support for this amendment increased to at least 80% of trusted

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod transactions;
 pub mod utils;
 
 pub use requests::*;
+pub use transactions::*;
 
 use alloc::borrow::Cow;
 use alloc::borrow::Cow::Borrowed;
@@ -81,36 +82,36 @@ pub enum RequestMethod {
 pub enum AccountSetFlag {
     /// Track the ID of this account's most recent transaction
     /// Required for AccountTxnID
-    AsfAccountTxnID = 0x00000005,
+    AsfAccountTxnID,
     /// Enable to allow another account to mint non-fungible tokens (NFTokens)
     /// on this account's behalf. Specify the authorized account in the
     /// NFTokenMinter field of the AccountRoot object. This is an experimental
     /// field to enable behavior for NFToken support.
-    AsfAuthorizedNFTokenMinter = 0x0000000A,
+    AsfAuthorizedNFTokenMinter,
     /// Enable rippling on this account's trust lines by default.
-    AsfDefaultRipple = 0x00000008,
+    AsfDefaultRipple,
     /// Enable Deposit Authorization on this account.
     /// (Added by the DepositAuth amendment.)
-    AsfDepositAuth = 0x00000009,
+    AsfDepositAuth,
     /// Disallow use of the master key pair. Can only be enabled if the
     /// account has configured another way to sign transactions, such as
     /// a Regular Key or a Signer List.
-    AsfDisableMaster = 0x00000004,
+    AsfDisableMaster,
     /// XRP should not be sent to this account.
     /// (Enforced by client applications, not by rippled)
-    AsfDisallowXRP = 0x00000003,
+    AsfDisallowXRP,
     /// Freeze all assets issued by this account.
-    AsfGlobalFreeze = 0x00000007,
+    AsfGlobalFreeze,
     /// Permanently give up the ability to freeze individual
     /// trust lines or disable Global Freeze. This flag can never
     /// be disabled after being enabled.
-    AsfNoFreeze = 0x00000006,
+    AsfNoFreeze,
     /// Require authorization for users to hold balances issued by
     /// this address. Can only be enabled if the address has no
     /// trust lines connected to it.
-    AsfRequireAuth = 0x00000002,
+    AsfRequireAuth,
     /// Require a destination tag to send transactions to this account.
-    AsfRequireDest = 0x00000001,
+    AsfRequireDest,
 }
 
 /// Transactions of the NFTokenCreateOffer type support additional values
@@ -122,7 +123,7 @@ pub enum AccountSetFlag {
 pub enum NFTokenCreateOfferFlag {
     /// If enabled, indicates that the offer is a sell offer.
     /// Otherwise, it is a buy offer.
-    TfSellOffer = 0x00000001,
+    TfSellOffer,
 }
 
 /// Transactions of the NFTokenMint type support additional values
@@ -134,17 +135,17 @@ pub enum NFTokenCreateOfferFlag {
 pub enum NFTokenMintFlag {
     /// Allow the issuer (or an entity authorized by the issuer) to
     /// destroy the minted NFToken. (The NFToken's owner can always do so.)
-    TfBurnable = 0x00000001,
+    TfBurnable,
     /// The minted NFToken can only be bought or sold for XRP.
     /// This can be desirable if the token has a transfer fee and the issuer
     /// does not want to receive fees in non-XRP currencies.
-    TfOnlyXRP = 0x00000002,
+    TfOnlyXRP,
     /// Automatically create trust lines from the issuer to hold transfer
     /// fees received from transferring the minted NFToken.
-    TfTrustline = 0x00000004,
+    TfTrustline,
     /// The minted NFToken can be transferred to others. If this flag is not
     /// enabled, the token can still be transferred from or to the issuer.
-    TfTransferable = 0x00000008,
+    TfTransferable,
 }
 
 /// Transactions of the OfferCreate type support additional values
@@ -157,22 +158,22 @@ pub enum OfferCreateFlag {
     /// If enabled, the Offer does not consume Offers that exactly match it,
     /// and instead becomes an Offer object in the ledger.
     /// It still consumes Offers that cross it.
-    TfPassive = 0x00010000,
+    TfPassive,
     /// Treat the Offer as an Immediate or Cancel order. The Offer never creates
     /// an Offer object in the ledger: it only trades as much as it can by
     /// consuming existing Offers at the time the transaction is processed. If no
     /// Offers match, it executes "successfully" without trading anything.
     /// In this case, the transaction still uses the result code tesSUCCESS.
-    TfImmediateOrCancel = 0x00020000,
+    TfImmediateOrCancel,
     /// Treat the offer as a Fill or Kill order . The Offer never creates an Offer
     /// object in the ledger, and is canceled if it cannot be fully filled at the
     /// time of execution. By default, this means that the owner must receive the
     /// full TakerPays amount; if the tfSell flag is enabled, the owner must be
     /// able to spend the entire TakerGets amount instead.
-    TfFillOrKill = 0x00040000,
+    TfFillOrKill,
     /// Exchange the entire TakerGets amount, even if it means obtaining more than
     /// the TakerPays amount in exchange.
-    TfSell = 0x00080000,
+    TfSell,
 }
 
 /// Transactions of the Payment type support additional values
@@ -185,15 +186,15 @@ pub enum PaymentFlag {
     /// Do not use the default path; only use paths included in the Paths field.
     /// This is intended to force the transaction to take arbitrage opportunities.
     /// Most clients do not need this.
-    TfNoDirectRipple = 0x00010000,
+    TfNoDirectRipple,
     /// If the specified Amount cannot be sent without spending more than SendMax,
     /// reduce the received amount instead of failing outright.
     /// See Partial Payments for more details.
-    TfPartialPayment = 0x00020000,
+    TfPartialPayment,
     /// Only take paths where all the conversions have an input:output ratio that
     /// is equal or better than the ratio of Amount:SendMax.
     /// See Limit Quality for details.
-    TfLimitQuality = 0x00040000,
+    TfLimitQuality,
 }
 
 /// Transactions of the PaymentChannelClaim type support additional values
@@ -206,7 +207,7 @@ pub enum PaymentChannelClaimFlag {
     /// Clear the channel's Expiration time. (Expiration is different from the
     /// channel's immutable CancelAfter time.) Only the source address of the
     /// payment channel can use this flag.
-    TfRenew = 0x00010000,
+    TfRenew,
     /// Request to close the channel. Only the channel source and destination
     /// addresses can use this flag. This flag closes the channel immediately if
     /// it has no more XRP allocated to it after processing the current claim,
@@ -217,7 +218,7 @@ pub enum PaymentChannelClaimFlag {
     /// SettleDelay time, unless the channel already has an earlier Expiration time.)
     /// If the destination address uses this flag when the channel still holds XRP,
     /// any XRP that remains after processing the claim is returned to the source address.
-    TfClose = 0x00020000,
+    TfClose,
 }
 
 /// Transactions of the TrustSet type support additional values
@@ -229,16 +230,16 @@ pub enum PaymentChannelClaimFlag {
 pub enum TrustSetFlag {
     /// Authorize the other party to hold currency issued by this account.
     /// (No effect unless using the asfRequireAuth AccountSet flag.) Cannot be unset.
-    TfSetAuth = 0x00010000,
+    TfSetAuth,
     /// Enable the No Ripple flag, which blocks rippling between two trust lines
     /// of the same currency if this flag is enabled on both.
-    TfSetNoRipple = 0x00020000,
+    TfSetNoRipple,
     /// Disable the No Ripple flag, allowing rippling on this trust line.)
-    TfClearNoRipple = 0x00040000,
+    TfClearNoRipple,
     /// Freeze the trust line.
-    TfSetFreeze = 0x00100000,
+    TfSetFreeze,
     /// Unfreeze the trust line.
-    TfClearFreeze = 0x00200000,
+    TfClearFreeze,
 }
 
 /// Pseudo-Transaction of the EnableAmendment type support additional values
@@ -250,10 +251,10 @@ pub enum TrustSetFlag {
 pub enum EnableAmendmentFlag {
     /// Support for this amendment increased to at least 80% of trusted
     /// validators starting with this ledger version.
-    TfGotMajority = 0x00010000,
+    TfGotMajority,
     /// Support for this amendment decreased to less than 80% of trusted
     /// validators starting with this ledger version.
-    TfLostMajority = 0x00020000,
+    TfLostMajority,
 }
 
 /// Represents the object types that an AccountObjects
@@ -294,7 +295,7 @@ pub enum Currency {
 }
 
 /// Enum containing the different Transaction types.
-#[derive(Debug, Clone, Serialize, Deserialize, Display)]
+#[derive(Debug, Clone, Serialize, Deserialize, Display, PartialEq)]
 #[serde(tag = "transaction_type")]
 pub enum TransactionType {
     AccountDelete,

--- a/src/models/transactions.rs
+++ b/src/models/transactions.rs
@@ -30,8 +30,8 @@ pub struct AccountDelete<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -50,17 +50,14 @@ pub struct AccountDelete<'a> {
 
 impl Transaction for AccountDelete<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `AccountDelete` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `AccountDelete` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -96,14 +93,14 @@ pub struct AccountSet<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     ticket_sequence: Option<u32>,
     txn_signature: Option<&'a str>,
-    flags: Option<Vec<u32>>,
+    flags: Option<Vec<AccountSetFlag>>,
     memos: Option<Vec<Memo<'a>>>,
     signers: Option<Vec<Signer<'a>>>,
     /// The custom fields for the AccountSet model.
@@ -122,14 +119,28 @@ pub struct AccountSet<'a> {
 
 impl Transaction for AccountSet<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `AccountSet` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `AccountSet` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
         let mut flags_int: u32 = 0;
         if self.flags.is_some() {
             for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
+                match flag {
+                    AccountSetFlag::AsfAccountTxnID => flags_int += 0x00000005,
+                    AccountSetFlag::AsfAuthorizedNFTokenMinter => flags_int += 0x0000000A,
+                    AccountSetFlag::AsfDefaultRipple => flags_int += 0x00000008,
+                    AccountSetFlag::AsfDepositAuth => flags_int += 0x00000009,
+                    AccountSetFlag::AsfDisableMaster => flags_int += 0x00000004,
+                    AccountSetFlag::AsfDisallowXRP => flags_int += 0x00000003,
+                    AccountSetFlag::AsfGlobalFreeze => flags_int += 0x00000007,
+                    AccountSetFlag::AsfNoFreeze => flags_int += 0x00000006,
+                    AccountSetFlag::AsfRequireAuth => flags_int += 0x00000002,
+                    AccountSetFlag::AsfRequireDest => flags_int += 0x00000001,
+                }
             }
         }
         flags_int
@@ -170,8 +181,8 @@ pub struct CheckCancel<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -189,17 +200,14 @@ pub struct CheckCancel<'a> {
 
 impl Transaction for CheckCancel<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `CheckCancel` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `CheckCancel` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -237,8 +245,8 @@ pub struct CheckCash<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -258,17 +266,14 @@ pub struct CheckCash<'a> {
 
 impl Transaction for CheckCash<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `CheckCash` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `CheckCash` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -304,8 +309,8 @@ pub struct CheckCreate<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -327,17 +332,14 @@ pub struct CheckCreate<'a> {
 
 impl Transaction for CheckCreate<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `CheckCreate` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `CheckCreate` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -373,8 +375,8 @@ pub struct DepositPreauth<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -393,17 +395,14 @@ pub struct DepositPreauth<'a> {
 
 impl Transaction for DepositPreauth<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `DepositPreauth` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `DepositPreauth` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -438,8 +437,8 @@ pub struct EscrowCancel<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -458,17 +457,14 @@ pub struct EscrowCancel<'a> {
 
 impl Transaction for EscrowCancel<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `EscrowCancel` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `EscrowCancel` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -503,8 +499,8 @@ pub struct EscrowCreate<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -527,17 +523,14 @@ pub struct EscrowCreate<'a> {
 
 impl Transaction for EscrowCreate<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `EscrowCreate` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `EscrowCreate` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -572,8 +565,8 @@ pub struct EscrowFinish<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -594,17 +587,14 @@ pub struct EscrowFinish<'a> {
 
 impl Transaction for EscrowFinish<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `EscrowFinish` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `EscrowFinish` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -639,8 +629,8 @@ pub struct NFTokenAcceptOffer<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -660,17 +650,14 @@ pub struct NFTokenAcceptOffer<'a> {
 
 impl Transaction for NFTokenAcceptOffer<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `NFTokenAcceptOffer` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `NFTokenAcceptOffer` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -706,8 +693,8 @@ pub struct NFTokenBurn<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -726,17 +713,14 @@ pub struct NFTokenBurn<'a> {
 
 impl Transaction for NFTokenBurn<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `NFTokenBurn` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `NFTokenBurn` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -771,8 +755,8 @@ pub struct NFTokenCancelOffer<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -792,17 +776,14 @@ pub struct NFTokenCancelOffer<'a> {
 
 impl Transaction for NFTokenCancelOffer<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `NFTokenCancelOffer` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `NFTokenCancelOffer` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -839,14 +820,14 @@ pub struct NFTokenCreateOffer<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     ticket_sequence: Option<u32>,
     txn_signature: Option<&'a str>,
-    flags: Option<Vec<u32>>,
+    flags: Option<Vec<NFTokenCreateOfferFlag>>,
     memos: Option<Vec<Memo<'a>>>,
     signers: Option<Vec<Signer<'a>>>,
     /// The custom fields for the NFTokenCreateOffer model.
@@ -862,14 +843,19 @@ pub struct NFTokenCreateOffer<'a> {
 
 impl Transaction for NFTokenCreateOffer<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `NFTokenCreateOffer` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `NFTokenCreateOffer` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
         let mut flags_int: u32 = 0;
         if self.flags.is_some() {
             for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
+                match flag {
+                    &NFTokenCreateOfferFlag::TfSellOffer => flags_int += 0x00000001,
+                }
             }
         }
         flags_int
@@ -908,14 +894,14 @@ pub struct NFTokenMint<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     ticket_sequence: Option<u32>,
     txn_signature: Option<&'a str>,
-    flags: Option<Vec<u32>>,
+    flags: Option<Vec<NFTokenMintFlag>>,
     memos: Option<Vec<Memo<'a>>>,
     signers: Option<Vec<Signer<'a>>>,
     /// The custom fields for the NFTokenMint model.
@@ -930,14 +916,22 @@ pub struct NFTokenMint<'a> {
 
 impl Transaction for NFTokenMint<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `NFTokenMint` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `NFTokenMint` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
         let mut flags_int: u32 = 0;
         if self.flags.is_some() {
             for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
+                match flag {
+                    NFTokenMintFlag::TfBurnable => flags_int += 0x00000001,
+                    NFTokenMintFlag::TfOnlyXRP => flags_int += 0x00000002,
+                    NFTokenMintFlag::TfTrustline => flags_int += 0x00000004,
+                    NFTokenMintFlag::TfTransferable => flags_int += 0x00000008,
+                }
             }
         }
         flags_int
@@ -975,8 +969,8 @@ pub struct OfferCancel<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -994,17 +988,14 @@ pub struct OfferCancel<'a> {
 
 impl Transaction for OfferCancel<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `OfferCancel` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `OfferCancel` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -1039,14 +1030,14 @@ pub struct OfferCreate<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     ticket_sequence: Option<u32>,
     txn_signature: Option<&'a str>,
-    flags: Option<Vec<u32>>,
+    flags: Option<Vec<OfferCreateFlag>>,
     memos: Option<Vec<Memo<'a>>>,
     signers: Option<Vec<Signer<'a>>>,
     /// The custom fields for the OfferCreate model.
@@ -1061,14 +1052,22 @@ pub struct OfferCreate<'a> {
 
 impl Transaction for OfferCreate<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `OfferCreate` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `OfferCreate` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
         let mut flags_int: u32 = 0;
         if self.flags.is_some() {
             for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
+                match flag {
+                    OfferCreateFlag::TfPassive => flags_int += 0x00010000,
+                    OfferCreateFlag::TfImmediateOrCancel => flags_int += 0x00020000,
+                    OfferCreateFlag::TfFillOrKill => flags_int += 0x00040000,
+                    OfferCreateFlag::TfSell => flags_int += 0x00080000,
+                }
             }
         }
         flags_int
@@ -1106,14 +1105,14 @@ pub struct Payment<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     ticket_sequence: Option<u32>,
     txn_signature: Option<&'a str>,
-    flags: Option<Vec<u32>>,
+    flags: Option<Vec<PaymentFlag>>,
     memos: Option<Vec<Memo<'a>>>,
     signers: Option<Vec<Signer<'a>>>,
     /// The custom fields for the Payment model.
@@ -1131,14 +1130,21 @@ pub struct Payment<'a> {
 
 impl Transaction for Payment<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `Payment` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `Payment` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
         let mut flags_int: u32 = 0;
         if self.flags.is_some() {
             for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
+                match flag {
+                    PaymentFlag::TfNoDirectRipple => flags_int += 0x00010000,
+                    PaymentFlag::TfPartialPayment => flags_int += 0x00020000,
+                    PaymentFlag::TfLimitQuality => flags_int += 0x00040000,
+                }
             }
         }
         flags_int
@@ -1177,14 +1183,14 @@ pub struct PaymentChannelClaim<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     ticket_sequence: Option<u32>,
     txn_signature: Option<&'a str>,
-    flags: Option<Vec<u32>>,
+    flags: Option<Vec<PaymentChannelClaimFlag>>,
     memos: Option<Vec<Memo<'a>>>,
     signers: Option<Vec<Signer<'a>>>,
     /// The custom fields for the PaymentChannelClaim model.
@@ -1200,14 +1206,20 @@ pub struct PaymentChannelClaim<'a> {
 
 impl Transaction for PaymentChannelClaim<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `PaymentChannelClaim` to json.")
+        let mut transaction_json = serde_json::to_value(&self)
+            .expect("Unable to serialize `PaymentChannelClaim` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
         let mut flags_int: u32 = 0;
         if self.flags.is_some() {
             for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
+                match flag {
+                    PaymentChannelClaimFlag::TfRenew => flags_int += 0x00010000,
+                    PaymentChannelClaimFlag::TfClose => flags_int += 0x00020000,
+                }
             }
         }
         flags_int
@@ -1245,8 +1257,8 @@ pub struct PaymentChannelCreate<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -1269,17 +1281,14 @@ pub struct PaymentChannelCreate<'a> {
 
 impl Transaction for PaymentChannelCreate<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `PaymentChannelCreate` to json.")
+        let mut transaction_json = serde_json::to_value(&self)
+            .expect("Unable to serialize `PaymentChannelCreate` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -1315,8 +1324,8 @@ pub struct PaymentChannelFund<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -1336,17 +1345,14 @@ pub struct PaymentChannelFund<'a> {
 
 impl Transaction for PaymentChannelFund<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `PaymentChannelFund` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `PaymentChannelFund` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -1385,8 +1391,8 @@ pub struct SetRegularKey<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -1404,17 +1410,14 @@ pub struct SetRegularKey<'a> {
 
 impl Transaction for SetRegularKey<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `SetRegularKey` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `SetRegularKey` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -1452,8 +1455,8 @@ pub struct SignerListSet<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -1471,17 +1474,14 @@ pub struct SignerListSet<'a> {
 
 impl Transaction for SignerListSet<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `TicketCreate` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `SignerListSet` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -1516,8 +1516,8 @@ pub struct TicketCreate<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
@@ -1535,17 +1535,14 @@ pub struct TicketCreate<'a> {
 
 impl Transaction for TicketCreate<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `TicketCreate` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `TicketCreate` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -1580,14 +1577,14 @@ pub struct TrustSet<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
-    last_ledger_sequence: Option<u64>,
+    sequence: Option<u32>,
+    last_ledger_sequence: Option<u32>,
     account_txn_id: Option<&'a str>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     ticket_sequence: Option<u32>,
     txn_signature: Option<&'a str>,
-    flags: Option<Vec<u32>>,
+    flags: Option<Vec<TrustSetFlag>>,
     memos: Option<Vec<Memo<'a>>>,
     signers: Option<Vec<Signer<'a>>>,
     /// The custom fields for the TrustSet model.
@@ -1601,14 +1598,23 @@ pub struct TrustSet<'a> {
 
 impl Transaction for TrustSet<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `TrustSet` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `TrustSet` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
         let mut flags_int: u32 = 0;
         if self.flags.is_some() {
             for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
+                match flag {
+                    TrustSetFlag::TfSetAuth => flags_int += 0x00010000,
+                    TrustSetFlag::TfSetNoRipple => flags_int += 0x00020000,
+                    TrustSetFlag::TfClearNoRipple => flags_int += 0x00040000,
+                    TrustSetFlag::TfSetFreeze => flags_int += 0x00100000,
+                    TrustSetFlag::TfClearFreeze => flags_int += 0x00200000,
+                }
             }
         }
         flags_int
@@ -1646,11 +1652,11 @@ pub struct EnableAmendment<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
+    sequence: Option<u32>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     txn_signature: Option<&'a str>,
-    flags: Option<Vec<u32>>,
+    flags: Option<Vec<EnableAmendmentFlag>>,
     /// The custom fields for the EnableAmendment model.
     ///
     /// See EnableAmendment fields:
@@ -1661,14 +1667,20 @@ pub struct EnableAmendment<'a> {
 
 impl Transaction for EnableAmendment<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `EnableAmendment` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `EnableAmendment` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
         let mut flags_int: u32 = 0;
         if self.flags.is_some() {
             for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
+                match flag {
+                    EnableAmendmentFlag::TfGotMajority => flags_int += 0x00010000,
+                    EnableAmendmentFlag::TfLostMajority => flags_int += 0x00020000,
+                }
             }
         }
         flags_int
@@ -1704,7 +1716,7 @@ pub struct SetFee<'a> {
     transaction_type: TransactionType,
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
+    sequence: Option<u32>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     txn_signature: Option<&'a str>,
@@ -1722,17 +1734,14 @@ pub struct SetFee<'a> {
 
 impl Transaction for SetFee<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `SetFee` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `SetFee` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -1766,7 +1775,7 @@ pub struct UNLModify<'a> {
     #[serde(default = "default_account_zero")]
     account: &'a str,
     fee: Option<&'a str>,
-    sequence: Option<u64>,
+    sequence: Option<u32>,
     signing_pub_key: Option<&'a str>,
     source_tag: Option<u32>,
     txn_signature: Option<&'a str>,
@@ -1782,17 +1791,14 @@ pub struct UNLModify<'a> {
 
 impl Transaction for UNLModify<'static> {
     fn to_json(&self) -> Value {
-        serde_json::to_value(&self).expect("Unable to serialize `UNLModify` to json.")
+        let mut transaction_json =
+            serde_json::to_value(&self).expect("Unable to serialize `UNLModify` to json.");
+        transaction_json["Flags"] = Value::from(self.iter_to_int());
+        transaction_json
     }
 
     fn iter_to_int(&self) -> u32 {
-        let mut flags_int: u32 = 0;
-        if self.flags.is_some() {
-            for flag in self.flags.as_ref().unwrap() {
-                flags_int += flag
-            }
-        }
-        flags_int
+        0
     }
 
     fn has_flag(&self) -> bool {
@@ -1804,5 +1810,125 @@ impl Transaction for UNLModify<'static> {
 
     fn get_transaction_type(&self) -> TransactionType {
         self.transaction_type.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::vec;
+
+    use super::*;
+
+    #[test]
+    fn test_to_json() {
+        let sequence: u32 = 1;
+        let last_ledger_sequence: u32 = 72779837;
+        let flags = vec![OfferCreateFlag::TfImmediateOrCancel];
+        let xrp_amount = "1000000";
+        let usd_amount = "0.3";
+        let offer_create: OfferCreate = OfferCreate {
+            transaction_type: TransactionType::OfferCreate,
+            account: "rpXhhWmCvDwkzNtRbm7mmD1vZqdfatQNEe",
+            fee: Some("10"),
+            sequence: Some(sequence),
+            last_ledger_sequence: Some(last_ledger_sequence),
+            account_txn_id: None,
+            signing_pub_key: None,
+            source_tag: None,
+            ticket_sequence: None,
+            txn_signature: None,
+            flags: Some(flags),
+            memos: None,
+            signers: None,
+            taker_gets: Currency::Xrp {
+                amount: Some(Borrowed(xrp_amount)),
+                currency: Borrowed("XRP"),
+            },
+            taker_pays: Currency::IssuedCurrency {
+                amount: Some(Borrowed(usd_amount)),
+                currency: Borrowed("USD"),
+                issuer: Borrowed("rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq"),
+            },
+            expiration: None,
+            offer_sequence: None,
+        };
+        let actual = offer_create.to_json();
+        let json = r#"{"Account":"rpXhhWmCvDwkzNtRbm7mmD1vZqdfatQNEe","Fee":"10","Sequence":1,"LastLedgerSequence":72779837,"Flags":131072,"TakerGets":{"amount":"1000000","currency":"XRP"},"TakerPays":{"amount":"0.3","currency":"USD","issuer":"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq"}}"#;
+        let expect: Value = serde_json::from_str(json).unwrap();
+        assert_eq!(actual, expect)
+    }
+
+    #[test]
+    fn test_has_flag() {
+        let sequence: u32 = 1;
+        let last_ledger_sequence: u32 = 72779837;
+        let flags = vec![OfferCreateFlag::TfImmediateOrCancel];
+        let xrp_amount = "1000000";
+        let usd_amount = "0.3";
+        let offer_create: OfferCreate = OfferCreate {
+            transaction_type: TransactionType::OfferCreate,
+            account: "rpXhhWmCvDwkzNtRbm7mmD1vZqdfatQNEe",
+            fee: Some("10"),
+            sequence: Some(sequence),
+            last_ledger_sequence: Some(last_ledger_sequence),
+            account_txn_id: None,
+            signing_pub_key: None,
+            source_tag: None,
+            ticket_sequence: None,
+            txn_signature: None,
+            flags: Some(flags),
+            memos: None,
+            signers: None,
+            taker_gets: Currency::Xrp {
+                amount: Some(Borrowed(xrp_amount)),
+                currency: Borrowed("XRP"),
+            },
+            taker_pays: Currency::IssuedCurrency {
+                amount: Some(Borrowed(usd_amount)),
+                currency: Borrowed("USD"),
+                issuer: Borrowed("rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq"),
+            },
+            expiration: None,
+            offer_sequence: None,
+        };
+        assert!(offer_create.has_flag())
+    }
+
+    #[test]
+    fn test_get_transaction_type() {
+        let sequence: u32 = 1;
+        let last_ledger_sequence: u32 = 72779837;
+        let flags = vec![OfferCreateFlag::TfImmediateOrCancel];
+        let xrp_amount = "1000000";
+        let usd_amount = "0.3";
+        let offer_create: OfferCreate = OfferCreate {
+            transaction_type: TransactionType::OfferCreate,
+            account: "rpXhhWmCvDwkzNtRbm7mmD1vZqdfatQNEe",
+            fee: Some("10"),
+            sequence: Some(sequence),
+            last_ledger_sequence: Some(last_ledger_sequence),
+            account_txn_id: None,
+            signing_pub_key: None,
+            source_tag: None,
+            ticket_sequence: None,
+            txn_signature: None,
+            flags: Some(flags),
+            memos: None,
+            signers: None,
+            taker_gets: Currency::Xrp {
+                amount: Some(Borrowed(xrp_amount)),
+                currency: Borrowed("XRP"),
+            },
+            taker_pays: Currency::IssuedCurrency {
+                amount: Some(Borrowed(usd_amount)),
+                currency: Borrowed("USD"),
+                issuer: Borrowed("rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq"),
+            },
+            expiration: None,
+            offer_sequence: None,
+        };
+        let actual = offer_create.get_transaction_type();
+        let expect = TransactionType::OfferCreate;
+        assert_eq!(actual, expect)
     }
 }

--- a/src/models/transactions.rs
+++ b/src/models/transactions.rs
@@ -1,0 +1,270 @@
+use crate::models::*;
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AccountDelete<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::account_delete")]
+    transaction_type: TransactionType,
+    destination: &'a str,
+    destination_tag: Option<u32>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AccountSet<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::account_set")]
+    transaction_type: TransactionType,
+    clear_flag: Option<u32>,
+    domain: Option<&'a str>,
+    email_hash: Option<&'a str>,
+    message_key: Option<&'a str>,
+    set_flag: Option<u32>,
+    transfer_rate: Option<u32>,
+    tick_size: Option<u32>,
+    nftoken_minter: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CheckCancel<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::check_cancel")]
+    transaction_type: TransactionType,
+    check_id: &'a str,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CheckCash<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::check_cash")]
+    transaction_type: TransactionType,
+    check_id: &'a str,
+    amount: Option<Currency>,
+    deliver_min: Option<Currency>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CheckCreate<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::check_create")]
+    transaction_type: TransactionType,
+    destination: &'a str,
+    send_max: Currency,
+    destination_tag: Option<u32>,
+    expiration: Option<u32>,
+    invoice_id: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DepositPreauth<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::deposit_preauth")]
+    transaction_type: TransactionType,
+    authorize: Option<&'a str>,
+    unauthorize: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EscrowCancel<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::escrow_cancel")]
+    transaction_type: TransactionType,
+    owner: &'a str,
+    offer_sequence: u32,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EscrowCreate<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::escrow_create")]
+    transaction_type: TransactionType,
+    amount: Currency,
+    destination: &'a str,
+    destination_tag: Option<&'a str>,
+    cancel_after: Option<u32>,
+    finish_after: Option<u32>,
+    condition: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EscrowFinish<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::escrow_finish")]
+    transaction_type: TransactionType,
+    owner: &'a str,
+    offer_sequence: u32,
+    condition: Option<&'a str>,
+    fulfillment: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NFTokenAcceptOffer<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::nftoken_accept_offer")]
+    transaction_type: TransactionType,
+    nftoken_sell_offer: Option<&'a str>,
+    nftoken_buy_offer: Option<&'a str>,
+    nftoken_broker_fee: Option<Currency>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NFTokenBurn<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::nftoken_burn")]
+    transaction_type: TransactionType,
+    account: &'a str,
+    nftoken_id: &'a str,
+    owner: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NFTokenCancelOffer<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::nftoken_cancel_offer")]
+    transaction_type: TransactionType,
+    // Lifetime issue
+    #[serde(borrow)]
+    nftoken_offers: Vec<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NFTokenCreateOffer<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::nftoken_create_offer")]
+    transaction_type: TransactionType,
+    nftoken_id: &'a str,
+    amount: Currency,
+    owner: Option<&'a str>,
+    expiration: Option<u32>,
+    destination: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NFTokenMint<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::nftoken_mint")]
+    transaction_type: TransactionType,
+    nftoken_taxon: u32,
+    issuer: Option<&'a str>,
+    transfer_fee: Option<u32>,
+    uri: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OfferCancel {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::offer_cancel")]
+    transaction_type: TransactionType,
+    offer_sequence: u32,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OfferCreate {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::offer_create")]
+    transaction_type: TransactionType,
+    taker_gets: Currency,
+    taker_pays: Currency,
+    expiration: Option<u32>,
+    offer_sequence: Option<u32>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Payment<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::payment")]
+    transaction_type: TransactionType,
+    amount: Currency,
+    destination: &'a str,
+    destination_tag: Option<u32>,
+    invoice_id: Option<u32>,
+    paths: Option<Vec<Vec<PathStep<'a>>>>,
+    send_max: Option<Currency>,
+    deliver_min: Option<Currency>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PaymentChannelClaim<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::payment_channel_claim")]
+    transaction_type: TransactionType,
+    channel: &'a str,
+    balance: Option<&'a str>,
+    amount: Option<&'a str>,
+    signature: Option<&'a str>,
+    public_key: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PaymentChannelCreate<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::payment_channel_create")]
+    transaction_type: TransactionType,
+    amount: Currency,
+    destination: &'a str,
+    settle_delay: u32,
+    public_key: &'a str,
+    cancel_after: Option<u32>,
+    destination_tag: Option<u32>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PaymentChannelFund<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::payment_channel_fund")]
+    transaction_type: TransactionType,
+    channel: &'a str,
+    amount: &'a str,
+    expiration: Option<u32>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SetRegularKey<'a> {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::set_regular_key")]
+    transaction_type: TransactionType,
+    regular_key: Option<&'a str>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TicketCreate {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::ticket_create")]
+    transaction_type: TransactionType,
+    ticket_count: u32,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TrustSet {
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::trust_set")]
+    transaction_type: TransactionType,
+    limit_amount: Currency,
+    quality_in: Option<u32>,
+    quality_out: Option<u32>,
+}

--- a/src/models/transactions.rs
+++ b/src/models/transactions.rs
@@ -1,24 +1,115 @@
+//! Transaction models.
+
 use crate::models::*;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+/// Transaction
+
+/// An AccountDelete transaction deletes an account and any objects it
+/// owns in the XRP Ledger, if possible, sending the account's remaining
+/// XRP to a specified destination account. See Deletion of Accounts for
+/// the requirements to delete an account.
+///
+/// See AccountDelete:
+/// `<https://xrpl.org/accountdelete.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct AccountDelete<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::account_delete")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the AccountDelete model.
+    ///
+    /// See AccountDelete fields:
+    /// `<https://xrpl.org/accountdelete.html#accountdelete-fields>`
     destination: &'a str,
     destination_tag: Option<u32>,
 }
 
+impl Transaction for AccountDelete<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `AccountDelete` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// An AccountSet transaction modifies the properties of an
+/// account in the XRP Ledger.
+///
+/// See AccountSet:
+/// `<https://xrpl.org/accountset.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct AccountSet<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::account_set")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the AccountSet model.
+    ///
+    /// See AccountSet fields:
+    /// `<https://xrpl.org/accountset.html#accountset-fields>`
     clear_flag: Option<u32>,
     domain: Option<&'a str>,
     email_hash: Option<&'a str>,
@@ -29,32 +120,204 @@ pub struct AccountSet<'a> {
     nftoken_minter: Option<&'a str>,
 }
 
+impl Transaction for AccountSet<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `AccountSet` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Cancels an unredeemed Check, removing it from the ledger without
+/// sending any money. The source or the destination of the check can
+/// cancel a Check at any time using this transaction type. If the Check
+/// has expired, any address can cancel it.
+///
+/// See CheckCancel:
+/// `<https://xrpl.org/checkcancel.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct CheckCancel<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::check_cancel")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the CheckCancel model.
+    ///
+    /// See CheckCancel fields:
+    /// `<https://xrpl.org/checkcancel.html#checkcancel-fields>`
     check_id: &'a str,
 }
 
+impl Transaction for CheckCancel<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `CheckCancel` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Cancels an unredeemed Check, removing it from the ledger without
+/// sending any money. The source or the destination of the check can
+/// cancel a Check at any time using this transaction type. If the Check
+/// has expired, any address can cancel it.
+///
+/// See CheckCash:
+/// `<https://xrpl.org/checkcash.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct CheckCash<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::check_cash")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the CheckCash model.
+    ///
+    /// See CheckCash fields:
+    /// `<https://xrpl.org/checkcash.html#checkcash-fields>`
     check_id: &'a str,
     amount: Option<Currency>,
     deliver_min: Option<Currency>,
 }
 
+impl Transaction for CheckCash<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `CheckCash` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Create a Check object in the ledger, which is a deferred
+/// payment that can be cashed by its intended destination.
+///
+/// See CheckCreate:
+/// `<https://xrpl.org/checkcreate.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct CheckCreate<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::check_create")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the CheckCreate model.
+    ///
+    /// See CheckCreate fields:
+    /// `<https://xrpl.org/checkcreate.html#checkcreate-fields>`
     destination: &'a str,
     send_max: Currency,
     destination_tag: Option<u32>,
@@ -62,32 +325,198 @@ pub struct CheckCreate<'a> {
     invoice_id: Option<&'a str>,
 }
 
+impl Transaction for CheckCreate<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `CheckCreate` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// A DepositPreauth transaction gives another account pre-approval
+/// to deliver payments to the sender of this transaction.
+///
+/// See DepositPreauth:
+/// `<https://xrpl.org/depositpreauth.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct DepositPreauth<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::deposit_preauth")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the DepositPreauth model.
+    ///
+    /// See DepositPreauth fields:
+    /// `<https://xrpl.org/depositpreauth.html#depositpreauth-fields>`
     authorize: Option<&'a str>,
     unauthorize: Option<&'a str>,
 }
 
+impl Transaction for DepositPreauth<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `DepositPreauth` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Cancels an Escrow and returns escrowed XRP to the sender.
+///
+/// See EscrowCancel:
+/// `<https://xrpl.org/escrowcancel.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct EscrowCancel<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::escrow_cancel")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the EscrowCancel model.
+    ///
+    /// See EscrowCancel fields:
+    /// `<https://xrpl.org/escrowcancel.html#escrowcancel-flags>`
     owner: &'a str,
     offer_sequence: u32,
 }
 
+impl Transaction for EscrowCancel<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `EscrowCancel` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Creates an Escrow, which sequests XRP until the escrow process either finishes or is canceled.
+///
+/// See EscrowCreate:
+/// `<https://xrpl.org/escrowcreate.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct EscrowCreate<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::escrow_create")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the EscrowCreate model.
+    ///
+    /// See EscrowCreate fields:
+    /// `<https://xrpl.org/escrowcreate.html#escrowcreate-flags>`
     amount: Currency,
     destination: &'a str,
     destination_tag: Option<&'a str>,
@@ -96,57 +525,334 @@ pub struct EscrowCreate<'a> {
     condition: Option<&'a str>,
 }
 
+impl Transaction for EscrowCreate<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `EscrowCreate` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Finishes an Escrow and delivers XRP from a held payment to the recipient.
+///
+/// See EscrowFinish:
+/// `<https://xrpl.org/escrowfinish.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct EscrowFinish<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::escrow_finish")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the EscrowFinish model.
+    ///
+    /// See EscrowFinish fields:
+    /// `<https://xrpl.org/escrowfinish.html#escrowfinish-fields>`
     owner: &'a str,
     offer_sequence: u32,
     condition: Option<&'a str>,
     fulfillment: Option<&'a str>,
 }
 
+impl Transaction for EscrowFinish<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `EscrowFinish` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Accept offers to buy or sell an NFToken.
+///
+/// See NFTokenAcceptOffer:
+/// `<https://xrpl.org/nftokenacceptoffer.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct NFTokenAcceptOffer<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::nftoken_accept_offer")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the NFTokenAcceptOffer model.
+    ///
+    /// See NFTokenAcceptOffer fields:
+    /// `<https://xrpl.org/nftokenacceptoffer.html#nftokenacceptoffer-fields>`
     nftoken_sell_offer: Option<&'a str>,
     nftoken_buy_offer: Option<&'a str>,
     nftoken_broker_fee: Option<Currency>,
 }
 
+impl Transaction for NFTokenAcceptOffer<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `NFTokenAcceptOffer` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Removes a NFToken object from the NFTokenPage in which it is being held,
+/// effectively removing the token from the ledger (burning it).
+///
+/// See NFTokenBurn:
+/// `<https://xrpl.org/nftokenburn.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct NFTokenBurn<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::nftoken_burn")]
     transaction_type: TransactionType,
     account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the NFTokenBurn model.
+    ///
+    /// See NFTokenBurn fields:
+    /// `<https://xrpl.org/nftokenburn.html#nftokenburn-fields>`
     nftoken_id: &'a str,
     owner: Option<&'a str>,
 }
 
+impl Transaction for NFTokenBurn<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `NFTokenBurn` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Cancels existing token offers created using NFTokenCreateOffer.
+///
+/// See NFTokenCancelOffer:
+/// `<https://xrpl.org/nftokencanceloffer.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct NFTokenCancelOffer<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::nftoken_cancel_offer")]
     transaction_type: TransactionType,
-    // Lifetime issue
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the NFTokenCancelOffer model.
+    ///
+    /// See NFTokenCancelOffer fields:
+    /// `<https://xrpl.org/nftokencanceloffer.html#nftokencanceloffer-fields>`
+    /// Lifetime issue
     #[serde(borrow)]
     nftoken_offers: Vec<&'a str>,
 }
 
+impl Transaction for NFTokenCancelOffer<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `NFTokenCancelOffer` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Creates either a new Sell offer for an NFToken owned by
+/// the account executing the transaction, or a new Buy
+/// offer for an NFToken owned by another account.
+///
+/// See NFTokenCreateOffer:
+/// `<https://xrpl.org/nftokencreateoffer.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct NFTokenCreateOffer<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::nftoken_create_offer")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the NFTokenCreateOffer model.
+    ///
+    /// See NFTokenCreateOffer fields:
+    /// `<https://xrpl.org/nftokencreateoffer.html#nftokencreateoffer-fields>`
     nftoken_id: &'a str,
     amount: Currency,
     owner: Option<&'a str>,
@@ -154,45 +860,266 @@ pub struct NFTokenCreateOffer<'a> {
     destination: Option<&'a str>,
 }
 
+impl Transaction for NFTokenCreateOffer<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `NFTokenCreateOffer` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// The NFTokenMint transaction creates a non-fungible token and adds it to
+/// the relevant NFTokenPage object of the NFTokenMinter as an NFToken object.
+///
+/// See NFTokenMint:
+/// `<https://xrpl.org/nftokenmint.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct NFTokenMint<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::nftoken_mint")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the NFTokenMint model.
+    ///
+    /// See NFTokenMint fields:
+    /// `<https://xrpl.org/nftokenmint.html#nftokenmint-fields>`
     nftoken_taxon: u32,
     issuer: Option<&'a str>,
     transfer_fee: Option<u32>,
     uri: Option<&'a str>,
 }
 
+impl Transaction for NFTokenMint<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `NFTokenMint` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Removes an Offer object from the XRP Ledger.
+///
+/// See OfferCancel:
+/// `<https://xrpl.org/offercancel.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct OfferCancel {
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
+pub struct OfferCancel<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::offer_cancel")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the OfferCancel model.
+    ///
+    /// See OfferCancel fields:
+    /// `<https://xrpl.org/offercancel.html#offercancel-fields>`
     offer_sequence: u32,
 }
 
+impl Transaction for OfferCancel<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `OfferCancel` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Places an Offer in the decentralized exchange.
+///
+/// See OfferCreate:
+/// `<https://xrpl.org/offercreate.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct OfferCreate {
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
+pub struct OfferCreate<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::offer_create")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the OfferCreate model.
+    ///
+    /// See OfferCreate fields:
+    /// `<https://xrpl.org/offercreate.html#offercreate-fields>`
     taker_gets: Currency,
     taker_pays: Currency,
     expiration: Option<u32>,
     offer_sequence: Option<u32>,
 }
 
+impl Transaction for OfferCreate<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `OfferCreate` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Transfers value from one account to another.
+///
+/// See Payment:
+/// `<https://xrpl.org/payment.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct Payment<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::payment")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the Payment model.
+    ///
+    /// See Payment fields:
+    /// `<https://xrpl.org/payment.html#payment-fields>`
     amount: Currency,
     destination: &'a str,
     destination_tag: Option<u32>,
@@ -202,12 +1129,68 @@ pub struct Payment<'a> {
     deliver_min: Option<Currency>,
 }
 
+impl Transaction for Payment<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `Payment` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Claim XRP from a payment channel, adjust
+/// the payment channel's expiration, or both.
+///
+/// See PaymentChannelClaim:
+/// `<https://xrpl.org/paymentchannelclaim.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct PaymentChannelClaim<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::payment_channel_claim")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the PaymentChannelClaim model.
+    ///
+    /// See PaymentChannelClaim fields:
+    /// `<https://xrpl.org/paymentchannelclaim.html#paymentchannelclaim-fields>`
     channel: &'a str,
     balance: Option<&'a str>,
     amount: Option<&'a str>,
@@ -215,12 +1198,67 @@ pub struct PaymentChannelClaim<'a> {
     public_key: Option<&'a str>,
 }
 
+impl Transaction for PaymentChannelClaim<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `PaymentChannelClaim` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Create a unidirectional channel and fund it with XRP.
+///
+/// See PaymentChannelCreate fields:
+/// `<https://xrpl.org/paymentchannelcreate.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct PaymentChannelCreate<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::payment_channel_create")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the PaymentChannelCreate model.
+    ///
+    /// See PaymentChannelCreate fields:
+    /// `<https://xrpl.org/paymentchannelcreate.html#paymentchannelcreate-fields>`
     amount: Currency,
     destination: &'a str,
     settle_delay: u32,
@@ -229,42 +1267,542 @@ pub struct PaymentChannelCreate<'a> {
     destination_tag: Option<u32>,
 }
 
+impl Transaction for PaymentChannelCreate<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `PaymentChannelCreate` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Add additional XRP to an open payment channel,
+/// and optionally update the expiration time of the channel.
+///
+/// See PaymentChannelFund:
+/// `<https://xrpl.org/paymentchannelfund.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct PaymentChannelFund<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::payment_channel_fund")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the PaymentChannelFund model.
+    ///
+    /// See PaymentChannelFund fields:
+    /// `<https://xrpl.org/paymentchannelfund.html#paymentchannelfund-fields>`
     channel: &'a str,
     amount: &'a str,
     expiration: Option<u32>,
 }
 
+impl Transaction for PaymentChannelFund<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `PaymentChannelFund` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// You can protect your account by assigning a regular key pair to
+/// it and using it instead of the master key pair to sign transactions
+/// whenever possible. If your regular key pair is compromised, but
+/// your master key pair is not, you can use a SetRegularKey transaction
+/// to regain control of your account.
+///
+/// See SetRegularKey:
+/// `<https://xrpl.org/setregularkey.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct SetRegularKey<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::set_regular_key")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the SetRegularKey model.
+    ///
+    /// See SetRegularKey fields:
+    /// `<https://xrpl.org/setregularkey.html#setregularkey-fields>`
     regular_key: Option<&'a str>,
 }
 
+impl Transaction for SetRegularKey<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `SetRegularKey` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// The SignerList object type represents a list of parties that,
+/// as a group, are authorized to sign a transaction in place of an
+/// individual account. You can create, replace, or remove a signer
+/// list using a SignerListSet transaction.
+///
+/// See TicketCreate:
+/// `<https://xrpl.org/signerlistset.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TicketCreate {
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
+pub struct SignerListSet<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::ticket_create")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the TicketCreate model.
+    ///
+    /// See TicketCreate fields:
+    /// `<https://xrpl.org/signerlistset.html#signerlistset-fields>`
+    signer_quorum: u32,
+}
+
+impl Transaction for SignerListSet<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `TicketCreate` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Sets aside one or more sequence numbers as Tickets.
+///
+/// See TicketCreate:
+/// `<https://xrpl.org/ticketcreate.html>`
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
+pub struct TicketCreate<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::ticket_create")]
+    transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the TicketCreate model.
+    ///
+    /// See TicketCreate fields:
+    /// `<https://xrpl.org/ticketcreate.html#ticketcreate-fields>`
     ticket_count: u32,
 }
 
+impl Transaction for TicketCreate<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `TicketCreate` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Create or modify a trust line linking two accounts.
+///
+/// See TrustSet:
+/// `<https://xrpl.org/trustset.html>`
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TrustSet {
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
+pub struct TrustSet<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
     #[serde(skip_serializing)]
     #[serde(default = "TransactionType::trust_set")]
     transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    last_ledger_sequence: Option<u64>,
+    account_txn_id: Option<&'a str>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    ticket_sequence: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    memos: Option<Vec<Memo<'a>>>,
+    signers: Option<Vec<Signer<'a>>>,
+    /// The custom fields for the TrustSet model.
+    ///
+    /// See TrustSet fields:
+    /// `<https://xrpl.org/trustset.html#trustset-fields>`
     limit_amount: Currency,
     quality_in: Option<u32>,
     quality_out: Option<u32>,
+}
+
+impl Transaction for TrustSet<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `TrustSet` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// Pseudo-Transactions
+
+/// See EnableAmendment:
+/// `<https://xrpl.org/enableamendment.html>`
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
+pub struct EnableAmendment<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::enable_amendment")]
+    transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    /// The custom fields for the EnableAmendment model.
+    ///
+    /// See EnableAmendment fields:
+    /// `<https://xrpl.org/enableamendment.html#enableamendment-fields>`
+    amendment: &'a str,
+    ledger_sequence: u32,
+}
+
+impl Transaction for EnableAmendment<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `EnableAmendment` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// See SetFee:
+/// `<https://xrpl.org/setfee.html>`
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
+pub struct SetFee<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::set_fee")]
+    transaction_type: TransactionType,
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    /// The custom fields for the SetFee model.
+    ///
+    /// See SetFee fields:
+    /// `<https://xrpl.org/setfee.html#setfee-fields>`
+    base_fee: u64,
+    reference_fee_units: u32,
+    reserve_base: u32,
+    reserve_increment: u32,
+    ledger_sequence: u32,
+}
+
+impl Transaction for SetFee<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `SetFee` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
+}
+
+/// See UNLModify:
+/// `<https://xrpl.org/unlmodify.html>`
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
+pub struct UNLModify<'a> {
+    /// The base fields for all transaction models.
+    ///
+    /// See Transaction Types:
+    /// `<https://xrpl.org/transaction-types.html>`
+    ///
+    /// See Transaction Common Fields:
+    /// `<https://xrpl.org/transaction-common-fields.html>`
+    #[serde(skip_serializing)]
+    #[serde(default = "TransactionType::unl_modify")]
+    transaction_type: TransactionType,
+    #[serde(default = "default_account_zero")]
+    account: &'a str,
+    fee: Option<&'a str>,
+    sequence: Option<u64>,
+    signing_pub_key: Option<&'a str>,
+    source_tag: Option<u32>,
+    txn_signature: Option<&'a str>,
+    flags: Option<Vec<u32>>,
+    /// The custom fields for the UNLModify model.
+    ///
+    /// See UNLModify fields:
+    /// `<https://xrpl.org/unlmodify.html#unlmodify-fields>`
+    ledger_sequence: u16,
+    unlmodify_disabling: u8,
+    unlmodify_validator: &'a str,
+}
+
+impl Transaction for UNLModify<'static> {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(&self).expect("Unable to serialize `UNLModify` to json.")
+    }
+
+    fn iter_to_int(&self) -> u32 {
+        let mut flags_int: u32 = 0;
+        if self.flags.is_some() {
+            for flag in self.flags.as_ref().unwrap() {
+                flags_int += flag
+            }
+        }
+        flags_int
+    }
+
+    fn has_flag(&self) -> bool {
+        if self.flags.is_some() && self.iter_to_int() > 0 {
+            return true;
+        }
+        false
+    }
+
+    fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type.clone()
+    }
 }

--- a/src/utils/xrpl_conversion.rs
+++ b/src/utils/xrpl_conversion.rs
@@ -51,18 +51,17 @@ fn _calculate_precision(value: &str) -> Result<usize, XRPRangeException> {
 /// Ensure that the value after being multiplied by the
 /// exponent does not contain a decimal.
 fn _verify_no_decimal(decimal: Decimal) -> Result<(), XRPRangeException> {
-    let value: String;
     let decimal = Decimal::from_u32(decimal.scale()).expect("_verify_no_decimal");
 
-    if decimal == Decimal::ZERO {
-        value = decimal.mantissa().to_string();
+    let value: String = if decimal == Decimal::ZERO {
+        decimal.mantissa().to_string()
     } else {
-        value = decimal
+        decimal
             .checked_mul(decimal)
             .or(Some(Decimal::ZERO))
             .unwrap()
-            .to_string();
-    }
+            .to_string()
+    };
 
     if value.contains('.') {
         Err(XRPRangeException::InvalidValueContainsDecimal)


### PR DESCRIPTION
## High Level Overview of Change

- Add transaction models
- Add transaction flags
- Remove `TransactionFields`
- Fix unnecessary late definitions of some vars.
- Rename `State` in `AccountObjectType` to `RippleState`

### Context of Change

To make it as easy as possible to define a transaction there should be transaction objects.
Because rust does not support inheritance of two structs each transaction contain the common fields, making the `TransactionFields` object unnecessary. Doing so makes it easier for the user to define the transaction (define one object instead of two). This PR also includes transaction flags.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

- `test_to_json` (tests `to_json` and `iter_to_flags`)
- `test_has_flag`
- `test_get_transaction_type`

## TODO

- [x] Add tests
- [x] Export transactions
- [x] Remove currently unneeded `TRANSACTION_HASH_PREFIX`
- [x] The field `flags` should be typed `Option<Vec<AccountSetFlag>>` instead of `Option<Vec<u32>>`. Unfortunately I currently have no solution getting the value from the `enum`, needed for `iter_to_int`. **HELP WANTED**

## Remarks
- I am still new to rust. This was the first time I really worked with markers. I orientated myself towards the existing `requests` objects. Please add/remove markers if it makes sense.
- The documentation describing the transactions currently is very simple, at some points. Feel free to suggest some more specific descriptions.

