### PR TITLE
Separate currency amount/currency

### DIFF
--- a/src/_serde/mod.rs
+++ b/src/_serde/mod.rs
@@ -54,39 +54,6 @@ pub mod txn_flags {
     }
 }
 
-/// Used for tagged variants in an `untagged` enum
-pub mod currency_xrp {
-    use super::HashMap;
-    use serde::de::Error;
-    use serde::{ser::SerializeMap, Deserialize};
-
-    pub fn serialize<S>(serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let xrp_currency = [("currency", "XRP")];
-        let mut map = serializer.serialize_map(Some(xrp_currency.len()))?;
-        for (k, v) in xrp_currency {
-            map.serialize_entry(k, v)?;
-        }
-        map.end()
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<(), D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let xrp_currency: HashMap<&str, &str> = HashMap::deserialize(deserializer)?;
-
-        if xrp_currency.get("currency").unwrap() == &"XRP" {
-            return Ok(());
-        }
-
-        // TODO: utilize anyhow and thiserror
-        Err("Could not deserialize XRP currency.").map_err(Error::custom)
-    }
-}
-
 /// Source: https://github.com/serde-rs/serde/issues/554#issuecomment-249211775
 // TODO: Find a way to `#[skip_serializing_none]`
 // TODO: Find a more generic way

--- a/src/models/amount/issued_currency_amount.rs
+++ b/src/models/amount/issued_currency_amount.rs
@@ -1,6 +1,6 @@
-use crate::models::amount::ValueAsDecimal;
 use crate::models::Model;
 use alloc::borrow::Cow;
+use core::convert::TryInto;
 use core::str::FromStr;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -14,12 +14,6 @@ pub struct IssuedCurrencyAmount<'a> {
 
 impl<'a> Model for IssuedCurrencyAmount<'a> {}
 
-impl<'a> ValueAsDecimal for IssuedCurrencyAmount<'a> {
-    fn as_decimal(&self) -> Result<Decimal, rust_decimal::Error> {
-        Decimal::from_str(&self.value)
-    }
-}
-
 impl<'a> IssuedCurrencyAmount<'a> {
     pub fn new(currency: Cow<'a, str>, issuer: Cow<'a, str>, value: Cow<'a, str>) -> Self {
         Self {
@@ -27,5 +21,13 @@ impl<'a> IssuedCurrencyAmount<'a> {
             issuer,
             value,
         }
+    }
+}
+
+impl<'a> TryInto<Decimal> for IssuedCurrencyAmount<'a> {
+    type Error = rust_decimal::Error;
+
+    fn try_into(self) -> Result<Decimal, Self::Error> {
+        Decimal::from_str(&self.value)
     }
 }

--- a/src/models/amount/issued_currency_amount.rs
+++ b/src/models/amount/issued_currency_amount.rs
@@ -16,7 +16,7 @@ impl<'a> Model for IssuedCurrencyAmount<'a> {}
 
 impl<'a> ValueAsDecimal for IssuedCurrencyAmount<'a> {
     fn as_decimal(&self) -> Result<Decimal, rust_decimal::Error> {
-        Decimal::from_str(&*self.value)
+        Decimal::from_str(&self.value)
     }
 }
 

--- a/src/models/amount/issued_currency_amount.rs
+++ b/src/models/amount/issued_currency_amount.rs
@@ -1,0 +1,31 @@
+use crate::models::amount::ValueAsDecimal;
+use crate::models::Model;
+use alloc::borrow::Cow;
+use core::str::FromStr;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+pub struct IssuedCurrencyAmount<'a> {
+    pub currency: Cow<'a, str>,
+    pub issuer: Cow<'a, str>,
+    pub value: Cow<'a, str>,
+}
+
+impl<'a> Model for IssuedCurrencyAmount<'a> {}
+
+impl<'a> ValueAsDecimal for IssuedCurrencyAmount<'a> {
+    fn as_decimal(&self) -> Result<Decimal, rust_decimal::Error> {
+        Decimal::from_str(&*self.value)
+    }
+}
+
+impl<'a> IssuedCurrencyAmount<'a> {
+    pub fn new(currency: Cow<'a, str>, issuer: Cow<'a, str>, value: Cow<'a, str>) -> Self {
+        Self {
+            currency,
+            issuer,
+            value,
+        }
+    }
+}

--- a/src/models/amount/mod.rs
+++ b/src/models/amount/mod.rs
@@ -1,6 +1,7 @@
 pub mod issued_currency_amount;
 pub mod xrp_amount;
 
+use core::convert::TryInto;
 pub use issued_currency_amount::*;
 use rust_decimal::{Decimal, Error};
 pub use xrp_amount::*;
@@ -9,10 +10,6 @@ use crate::models::Model;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 
-pub trait ValueAsDecimal {
-    fn as_decimal(&self) -> Result<Decimal, Error>;
-}
-
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Display)]
 #[serde(untagged)]
 pub enum Amount<'a> {
@@ -20,11 +17,13 @@ pub enum Amount<'a> {
     XRPAmount(XRPAmount<'a>),
 }
 
-impl<'a> ValueAsDecimal for Amount<'a> {
-    fn as_decimal(&self) -> Result<Decimal, Error> {
+impl<'a> TryInto<Decimal> for Amount<'a> {
+    type Error = Error;
+
+    fn try_into(self) -> Result<Decimal, Self::Error> {
         match self {
-            Amount::IssuedCurrencyAmount(amount) => amount.as_decimal(),
-            Amount::XRPAmount(amount) => amount.as_decimal(),
+            Amount::IssuedCurrencyAmount(amount) => amount.try_into(),
+            Amount::XRPAmount(amount) => amount.try_into(),
         }
     }
 }

--- a/src/models/amount/mod.rs
+++ b/src/models/amount/mod.rs
@@ -1,0 +1,63 @@
+pub mod issued_currency_amount;
+pub mod xrp_amount;
+
+pub use issued_currency_amount::*;
+use rust_decimal::{Decimal, Error};
+pub use xrp_amount::*;
+
+use crate::models::Model;
+use serde::{Deserialize, Serialize};
+use strum_macros::Display;
+
+pub trait ValueAsDecimal {
+    fn as_decimal(&self) -> Result<Decimal, Error>;
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Display)]
+#[serde(untagged)]
+pub enum Amount<'a> {
+    IssuedCurrencyAmount(IssuedCurrencyAmount<'a>),
+    XRPAmount(XRPAmount<'a>),
+}
+
+impl<'a> ValueAsDecimal for Amount<'a> {
+    fn as_decimal(&self) -> Result<Decimal, Error> {
+        match self {
+            Amount::IssuedCurrencyAmount(amount) => amount.as_decimal(),
+            Amount::XRPAmount(amount) => amount.as_decimal(),
+        }
+    }
+}
+
+impl<'a> Model for Amount<'a> {}
+
+impl<'a> Default for Amount<'a> {
+    fn default() -> Self {
+        Self::XRPAmount("0".into())
+    }
+}
+
+impl<'a> Amount<'a> {
+    pub fn is_xrp(&self) -> bool {
+        match self {
+            Amount::IssuedCurrencyAmount(_) => false,
+            Amount::XRPAmount(_) => true,
+        }
+    }
+
+    pub fn is_issued_currency(&self) -> bool {
+        !self.is_xrp()
+    }
+}
+
+impl<'a> From<IssuedCurrencyAmount<'a>> for Amount<'a> {
+    fn from(value: IssuedCurrencyAmount<'a>) -> Self {
+        Self::IssuedCurrencyAmount(value)
+    }
+}
+
+impl<'a> From<XRPAmount<'a>> for Amount<'a> {
+    fn from(value: XRPAmount<'a>) -> Self {
+        Self::XRPAmount(value)
+    }
+}

--- a/src/models/amount/xrp_amount.rs
+++ b/src/models/amount/xrp_amount.rs
@@ -1,0 +1,15 @@
+use crate::models::amount::ValueAsDecimal;
+use crate::models::Model;
+use alloc::borrow::Cow;
+use core::str::FromStr;
+use rust_decimal::Decimal;
+
+pub type XRPAmount<'a> = Cow<'a, str>;
+
+impl<'a> Model for XRPAmount<'a> {}
+
+impl<'a> ValueAsDecimal for XRPAmount<'a> {
+    fn as_decimal(&self) -> Result<Decimal, rust_decimal::Error> {
+        Decimal::from_str(&*self)
+    }
+}

--- a/src/models/amount/xrp_amount.rs
+++ b/src/models/amount/xrp_amount.rs
@@ -10,6 +10,6 @@ impl<'a> Model for XRPAmount<'a> {}
 
 impl<'a> ValueAsDecimal for XRPAmount<'a> {
     fn as_decimal(&self) -> Result<Decimal, rust_decimal::Error> {
-        Decimal::from_str(&*self)
+        Decimal::from_str(self)
     }
 }

--- a/src/models/amount/xrp_amount.rs
+++ b/src/models/amount/xrp_amount.rs
@@ -1,15 +1,31 @@
-use crate::models::amount::ValueAsDecimal;
 use crate::models::Model;
 use alloc::borrow::Cow;
+use core::convert::TryInto;
 use core::str::FromStr;
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 
-pub type XRPAmount<'a> = Cow<'a, str>;
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+pub struct XRPAmount<'a>(pub Cow<'a, str>);
 
 impl<'a> Model for XRPAmount<'a> {}
 
-impl<'a> ValueAsDecimal for XRPAmount<'a> {
-    fn as_decimal(&self) -> Result<Decimal, rust_decimal::Error> {
-        Decimal::from_str(self)
+impl<'a> From<Cow<'a, str>> for XRPAmount<'a> {
+    fn from(value: Cow<'a, str>) -> Self {
+        Self(value)
+    }
+}
+
+impl<'a> From<&'a str> for XRPAmount<'a> {
+    fn from(value: &'a str) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<'a> TryInto<Decimal> for XRPAmount<'a> {
+    type Error = rust_decimal::Error;
+
+    fn try_into(self) -> Result<Decimal, Self::Error> {
+        Decimal::from_str(&self.0)
     }
 }

--- a/src/models/currency/issued_currency.rs
+++ b/src/models/currency/issued_currency.rs
@@ -1,0 +1,61 @@
+use crate::models::amount::IssuedCurrencyAmount;
+use crate::models::currency::ToAmount;
+use crate::models::Model;
+use alloc::borrow::Cow;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+pub struct IssuedCurrency<'a> {
+    pub currency: Cow<'a, str>,
+    pub issuer: Cow<'a, str>,
+}
+
+impl<'a> Model for IssuedCurrency<'a> {}
+
+impl<'a> ToAmount<'a, IssuedCurrencyAmount<'a>> for IssuedCurrency<'a> {
+    fn to_amount(&self, value: Cow<'a, str>) -> IssuedCurrencyAmount<'a> {
+        IssuedCurrencyAmount::new(self.currency.clone(), self.issuer.clone(), value)
+    }
+}
+
+impl<'a> IssuedCurrency<'a> {
+    pub fn new(currency: Cow<'a, str>, issuer: Cow<'a, str>) -> Self {
+        Self { currency, issuer }
+    }
+}
+
+impl<'a> From<IssuedCurrencyAmount<'a>> for IssuedCurrency<'a> {
+    fn from(value: IssuedCurrencyAmount<'a>) -> Self {
+        Self {
+            currency: value.currency,
+            issuer: value.issuer,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_serde {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let issued_currency =
+            IssuedCurrency::new("TST".into(), "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd".into());
+        let issued_currency_json = serde_json::to_string(&issued_currency).unwrap();
+        let actual = issued_currency_json.as_str();
+        let expected = r#"{"currency":"TST","issuer":"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"}"#;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let issued_currency_json =
+            r#"{"currency":"TST","issuer":"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"}"#;
+        let actual = serde_json::from_str(issued_currency_json).unwrap();
+        let expected =
+            IssuedCurrency::new("TST".into(), "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd".into());
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/models/currency/mod.rs
+++ b/src/models/currency/mod.rs
@@ -1,0 +1,40 @@
+pub mod issued_currency;
+pub mod xrp;
+
+use crate::models::Model;
+use alloc::borrow::Cow;
+pub use issued_currency::*;
+use serde::{Deserialize, Serialize};
+use strum_macros::Display;
+pub use xrp::*;
+
+pub trait ToAmount<'a, A> {
+    fn to_amount(&self, value: Cow<'a, str>) -> A;
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Display)]
+#[serde(untagged)]
+pub enum Currency<'a> {
+    IssuedCurrency(IssuedCurrency<'a>),
+    XRP(XRP<'a>),
+}
+
+impl<'a> Model for Currency<'a> {}
+
+impl<'a> Default for Currency<'a> {
+    fn default() -> Self {
+        Self::XRP(XRP::new())
+    }
+}
+
+impl<'a> From<IssuedCurrency<'a>> for Currency<'a> {
+    fn from(value: IssuedCurrency<'a>) -> Self {
+        Self::IssuedCurrency(value)
+    }
+}
+
+impl<'a> From<XRP<'a>> for Currency<'a> {
+    fn from(value: XRP<'a>) -> Self {
+        Self::XRP(value)
+    }
+}

--- a/src/models/currency/xrp.rs
+++ b/src/models/currency/xrp.rs
@@ -1,0 +1,90 @@
+use crate::models::amount::XRPAmount;
+use crate::models::currency::ToAmount;
+use crate::models::Model;
+use alloc::borrow::Cow;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+pub struct XRP<'a> {
+    pub currency: Cow<'a, str>,
+}
+
+impl<'a> Model for XRP<'a> {}
+
+impl<'a> ToAmount<'a, XRPAmount<'a>> for XRP<'a> {
+    fn to_amount(&self, value: Cow<'a, str>) -> XRPAmount<'a> {
+        value as XRPAmount<'a>
+    }
+}
+
+impl<'a> XRP<'a> {
+    pub fn new() -> Self {
+        Self {
+            currency: "XRP".into(),
+        }
+    }
+}
+
+impl<'a> From<XRPAmount<'a>> for XRP<'a> {
+    fn from(_value: XRPAmount<'a>) -> Self {
+        Self {
+            currency: "XRP".into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_serde {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let xrp = XRP::new();
+        let xrp_json = serde_json::to_string(&xrp).unwrap();
+        let actual = xrp_json.as_str();
+        let expected = r#"{"currency":"XRP"}"#;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let xrp_json = r#"{"currency":"XRP"}"#;
+        let actual = serde_json::from_str(xrp_json).unwrap();
+        let expected = XRP::new();
+
+        assert_eq!(expected, actual);
+    }
+}
+
+#[cfg(test)]
+mod test_amount_currency_conversion {
+    use super::*;
+
+    #[test]
+    fn test_currency_to_amount() {
+        let xrp = XRP::new();
+        let actual = xrp.to_amount("10".into());
+        let expected: XRPAmount = "10".into();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_currency_from_amount() {
+        let xrp_amount: XRPAmount = "10".into();
+        let actual = XRP::from(xrp_amount);
+        let expected = XRP::new();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_amount_into_currency() {
+        let xrp_amount: XRPAmount = "10".into();
+        let actual: XRP = xrp_amount.into();
+        let expected = XRP::new();
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/models/currency/xrp.rs
+++ b/src/models/currency/xrp.rs
@@ -13,7 +13,7 @@ impl<'a> Model for XRP<'a> {}
 
 impl<'a> ToAmount<'a, XRPAmount<'a>> for XRP<'a> {
     fn to_amount(&self, value: Cow<'a, str>) -> XRPAmount<'a> {
-        value as XRPAmount<'a>
+        XRPAmount(value)
     }
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -7,6 +7,8 @@ pub mod requests;
 #[allow(clippy::too_many_arguments)]
 pub mod transactions;
 
+pub mod amount;
+pub mod currency;
 pub mod response;
 pub mod utils;
 
@@ -14,11 +16,10 @@ use derive_new::new;
 pub use model::Model;
 use serde::ser::SerializeMap;
 
-use crate::_serde::currency_xrp;
 use crate::_serde::HashMap;
 use crate::serde_with_tag;
 
-use alloc::borrow::Cow;
+use crate::models::currency::{Currency, XRP};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use strum_macros::AsRefStr;
@@ -129,94 +130,6 @@ pub enum AccountObjectType {
     Ticket,
 }
 
-/// Specifies a currency.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum Currency {
-    /// Specifies an issued currency.
-    IssuedCurrency {
-        currency: Cow<'static, str>,
-        issuer: Cow<'static, str>,
-    },
-    /// Specifies XRP.
-    #[serde(with = "currency_xrp")]
-    Xrp,
-}
-
-impl Currency {
-    /// Check wether the defined currency is XRP.
-    fn is_xrp(&self) -> bool {
-        match self {
-            Currency::IssuedCurrency {
-                currency: _,
-                issuer: _,
-            } => false,
-            Currency::Xrp => true,
-        }
-    }
-}
-
-/// Specifies a currency amount.
-///
-/// See Specifying Currency Amounts:
-/// `<https://xrpl.org/currency-formats.html#specifying-currency-amounts>`
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum Amount {
-    /// Specifies an amount in an issued currency.
-    IssuedCurrency {
-        currency: Cow<'static, str>,
-        issuer: Cow<'static, str>,
-        value: Cow<'static, str>,
-    },
-    /// Specifies an amount in XRP.
-    Xrp(Cow<'static, str>),
-}
-
-impl Default for Amount {
-    fn default() -> Self {
-        Self::Xrp(Cow::Borrowed("()"))
-    }
-}
-
-impl Amount {
-    /// Returns the specified currency value as `u32`.
-    fn get_value_as_u32(&self) -> u32 {
-        match self {
-            Amount::IssuedCurrency {
-                currency: _,
-                issuer: _,
-                value,
-            } => {
-                let value_as_u32: u32 = value
-                    .as_ref()
-                    .parse()
-                    .expect("Could not parse u32 from `value`");
-                value_as_u32
-            }
-            Amount::Xrp(value) => {
-                let value_as_u32: u32 = value
-                    .as_ref()
-                    .parse()
-                    .expect("Could not parse u32 from `value`");
-                value_as_u32
-            }
-        }
-    }
-
-    /// Check wether the defined currency amount is a XRP amount.
-    fn is_xrp(&self) -> bool {
-        match self {
-            Amount::IssuedCurrency {
-                currency: _,
-                issuer: _,
-                value: _,
-            } => false,
-            Amount::Xrp(_) => true,
-        }
-    }
-}
-
 /// Enum containing the different Transaction types.
 #[derive(Debug, Clone, Serialize, Deserialize, Display, PartialEq, Eq)]
 pub enum TransactionType {
@@ -312,8 +225,8 @@ pub struct Signer<'a> {
 }
 
 /// Returns a Currency as XRP for the currency, without a value.
-fn default_xrp_currency() -> Currency {
-    Currency::Xrp
+fn default_xrp_currency<'a>() -> Currency<'a> {
+    Currency::XRP(XRP::new())
 }
 
 /// For use with serde defaults.
@@ -468,6 +381,7 @@ impl RequestMethod {
 
 /// Standard functions for transactions.
 pub trait Transaction {
+    // TODO: use generic type
     fn has_flag(&self, flag: &Flag) -> bool {
         let _txn_flag = flag;
         false

--- a/src/models/requests/path_find.rs
+++ b/src/models/requests/path_find.rs
@@ -2,7 +2,8 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::models::{Currency, Model, PathStep, RequestMethod};
+use crate::models::currency::{Currency, XRP};
+use crate::models::{Model, PathStep, RequestMethod};
 
 /// A path is an array. Each member of a path is an object that specifies a step on that path.
 pub type Path<'a> = Vec<PathStep<'a>>;
@@ -16,10 +17,8 @@ pub type Path<'a> = Vec<PathStep<'a>>;
 ///
 /// See Path Find:
 /// `<https://xrpl.org/path_find.html>`
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
-#[serde(tag = "subcommand")]
-#[derive(Default)]
 pub enum PathFindSubcommand {
     #[default]
     Create,
@@ -72,12 +71,12 @@ pub struct PathFind<'a> {
     /// the value field (for non-XRP currencies). This requests a path
     /// to deliver as much as possible, while spending no more than
     /// the amount specified in send_max (if provided).
-    pub destination_amount: Currency,
+    pub destination_amount: Currency<'a>,
     /// The unique request id.
     pub id: Option<&'a str>,
     /// Currency Amount that would be spent in the transaction.
     /// Not compatible with source_currencies.
-    pub send_max: Option<Currency>,
+    pub send_max: Option<Currency<'a>>,
     /// Array of arrays of objects, representing payment paths to check.
     /// You can use this to keep updated on changes to particular paths
     /// you already know about, or to check the overall cost to make a
@@ -94,7 +93,7 @@ impl<'a> Default for PathFind<'a> {
             subcommand: Default::default(),
             source_account: "",
             destination_account: "",
-            destination_amount: Currency::Xrp,
+            destination_amount: Currency::XRP(XRP::new()),
             id: None,
             send_max: None,
             paths: None,
@@ -110,9 +109,9 @@ impl<'a> PathFind<'a> {
         subcommand: PathFindSubcommand,
         source_account: &'a str,
         destination_account: &'a str,
-        destination_amount: Currency,
+        destination_amount: Currency<'a>,
         id: Option<&'a str>,
-        send_max: Option<Currency>,
+        send_max: Option<Currency<'a>>,
         paths: Option<Vec<Vec<PathStep<'a>>>>,
     ) -> Self {
         Self {

--- a/src/models/requests/ripple_path_find.rs
+++ b/src/models/requests/ripple_path_find.rs
@@ -2,7 +2,8 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::models::{Currency, Model, RequestMethod};
+use crate::models::currency::XRP;
+use crate::models::{currency::Currency, Model, RequestMethod};
 
 /// The ripple_path_find method is a simpl<'a>ified version of
 /// the path_find method that provides a single response with
@@ -35,7 +36,7 @@ pub struct RipplePathFind<'a> {
     /// of the value field (for non-XRP currencies). This requests a
     /// path to deliver as much as possible, while spending no more
     /// than the amount specified in send_max (if provided).
-    pub destination_amount: Currency,
+    pub destination_amount: Currency<'a>,
     /// The unique request id.
     pub id: Option<&'a str>,
     /// A 20-byte hex string for the ledger version to use.
@@ -45,7 +46,7 @@ pub struct RipplePathFind<'a> {
     pub ledger_index: Option<&'a str>,
     /// Currency Amount that would be spent in the transaction.
     /// Cannot be used with source_currencies.
-    pub send_max: Option<Currency>,
+    pub send_max: Option<Currency<'a>>,
     /// Array of currencies that the source account might want
     /// to spend. Each entry in the array should be a JSON object
     /// with a mandatory currency field and optional issuer field,
@@ -53,7 +54,7 @@ pub struct RipplePathFind<'a> {
     /// more than 18 source currencies. By default, uses all source
     /// currencies available up to a maximum of 88 different
     /// currency/issuer pairs.
-    pub source_currencies: Option<Vec<Currency>>,
+    pub source_currencies: Option<Vec<Currency<'a>>>,
     /// The request method.
     #[serde(default = "RequestMethod::ripple_path_find")]
     pub command: RequestMethod,
@@ -64,7 +65,7 @@ impl<'a> Default for RipplePathFind<'a> {
         RipplePathFind {
             source_account: "",
             destination_account: "",
-            destination_amount: Currency::Xrp,
+            destination_amount: Currency::XRP(XRP::new()),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -81,12 +82,12 @@ impl<'a> RipplePathFind<'a> {
     fn new(
         source_account: &'a str,
         destination_account: &'a str,
-        destination_amount: Currency,
+        destination_amount: Currency<'a>,
         id: Option<&'a str>,
         ledger_hash: Option<&'a str>,
         ledger_index: Option<&'a str>,
-        send_max: Option<Currency>,
-        source_currencies: Option<Vec<Currency>>,
+        send_max: Option<Currency<'a>>,
+        source_currencies: Option<Vec<Currency<'a>>>,
     ) -> Self {
         Self {
             source_account,

--- a/src/models/requests/subscribe.rs
+++ b/src/models/requests/subscribe.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::models::{default_false, Currency, Model, RequestMethod, StreamParameter};
+use crate::models::{currency::Currency, default_false, Model, RequestMethod, StreamParameter};
 
 /// Format for elements in the `books` array for Subscribe only.
 ///
@@ -11,8 +11,8 @@ use crate::models::{default_false, Currency, Model, RequestMethod, StreamParamet
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
 pub struct Book<'a> {
-    pub taker_gets: Currency,
-    pub taker_pays: Currency,
+    pub taker_gets: Currency<'a>,
+    pub taker_pays: Currency<'a>,
     pub taker: &'a str,
     #[serde(default = "default_false")]
     pub snapshot: Option<bool>,

--- a/src/models/requests/unsubscribe.rs
+++ b/src/models/requests/unsubscribe.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::models::{default_false, Currency, Model, RequestMethod, StreamParameter};
+use crate::models::{currency::Currency, default_false, Model, RequestMethod, StreamParameter};
 
 /// Format for elements in the `books` array for Unsubscribe only.
 ///
@@ -10,9 +10,9 @@ use crate::models::{default_false, Currency, Model, RequestMethod, StreamParamet
 /// `<https://xrpl.org/unsubscribe.html>`
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
-pub struct Book {
-    pub taker_gets: Currency,
-    pub taker_pays: Currency,
+pub struct Book<'a> {
+    pub taker_gets: Currency<'a>,
+    pub taker_pays: Currency<'a>,
     #[serde(default = "default_false")]
     pub both: Option<bool>,
 }
@@ -33,7 +33,7 @@ pub struct Unsubscribe<'a> {
     /// Array of objects defining order books to unsubscribe
     /// from, as explained below.
     // TODO: USE `UnsubscribeBookFields` AS SOON AS LIFETIME ISSUES ARE FIXED
-    pub books: Option<Vec<Book>>,
+    pub books: Option<Vec<Book<'a>>>,
     /// Array of string names of generic streams to unsubscribe
     /// from, including ledger, server, transactions,
     /// and transactions_proposed.
@@ -74,7 +74,7 @@ impl<'a> Model for Unsubscribe<'a> {}
 impl<'a> Unsubscribe<'a> {
     fn new(
         id: Option<&'a str>,
-        books: Option<Vec<Book>>,
+        books: Option<Vec<Book<'a>>>,
         streams: Option<Vec<StreamParameter>>,
         accounts: Option<Vec<&'a str>>,
         accounts_proposed: Option<Vec<&'a str>>,

--- a/src/models/transactions/account_delete.rs
+++ b/src/models/transactions/account_delete.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// An AccountDelete transaction deletes an account and any objects it
@@ -31,7 +32,7 @@ pub struct AccountDelete<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -120,7 +121,7 @@ impl<'a> AccountDelete<'a> {
     fn new(
         account: &'a str,
         destination: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -161,7 +162,7 @@ mod test_serde {
         let default_txn = AccountDelete::new(
             "rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm",
             "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
-            Some("2000000"),
+            Some("2000000".into()),
             Some(2470665),
             None,
             None,
@@ -186,7 +187,7 @@ mod test_serde {
         let default_txn = AccountDelete::new(
             "rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm",
             "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
-            Some("2000000"),
+            Some("2000000".into()),
             Some(2470665),
             None,
             None,

--- a/src/models/transactions/account_set.rs
+++ b/src/models/transactions/account_set.rs
@@ -4,6 +4,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
 use strum_macros::{AsRefStr, Display, EnumIter};
 
+use crate::models::amount::XRPAmount;
 use crate::{
     _serde::txn_flags,
     constants::{
@@ -86,7 +87,7 @@ pub struct AccountSet<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -353,7 +354,7 @@ impl<'a> AccountSetError for AccountSet<'a> {
 impl<'a> AccountSet<'a> {
     fn new(
         account: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -633,7 +634,7 @@ mod test_serde {
     fn test_serialize() {
         let default_txn = AccountSet::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Some("12"),
+            Some("12".into()),
             Some(5),
             None,
             None,
@@ -665,7 +666,7 @@ mod test_serde {
     fn test_deserialize() {
         let default_txn = AccountSet::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Some("12"),
+            Some("12".into()),
             Some(5),
             None,
             None,

--- a/src/models/transactions/check_cancel.rs
+++ b/src/models/transactions/check_cancel.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// Cancels an unredeemed Check, removing it from the ledger without
@@ -31,7 +32,7 @@ pub struct CheckCancel<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -113,7 +114,7 @@ impl<'a> CheckCancel<'a> {
     fn new(
         account: &'a str,
         check_id: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -152,7 +153,7 @@ mod test_serde {
         let default_txn = CheckCancel::new(
             "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
             "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0",
-            Some("12"),
+            Some("12".into()),
             None,
             None,
             None,
@@ -176,7 +177,7 @@ mod test_serde {
         let default_txn = CheckCancel::new(
             "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
             "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0",
-            Some("12"),
+            Some("12".into()),
             None,
             None,
             None,

--- a/src/models/transactions/check_create.rs
+++ b/src/models/transactions/check_create.rs
@@ -2,7 +2,8 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::models::{model::Model, Amount, Memo, Signer, Transaction, TransactionType};
+use crate::models::amount::XRPAmount;
+use crate::models::{amount::Amount, model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// Create a Check object in the ledger, which is a deferred
 /// payment that can be cashed by its intended destination.
@@ -29,7 +30,7 @@ pub struct CheckCreate<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -75,7 +76,7 @@ pub struct CheckCreate<'a> {
     /// See CheckCreate fields:
     /// `<https://xrpl.org/checkcreate.html#checkcreate-fields>`
     pub destination: &'a str,
-    pub send_max: Amount,
+    pub send_max: Amount<'a>,
     pub destination_tag: Option<u32>,
     pub expiration: Option<u32>,
     #[serde(rename = "InvoiceID")]
@@ -119,8 +120,8 @@ impl<'a> CheckCreate<'a> {
     fn new(
         account: &'a str,
         destination: &'a str,
-        send_max: Amount,
-        fee: Option<&'a str>,
+        send_max: Amount<'a>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -159,7 +160,7 @@ impl<'a> CheckCreate<'a> {
 
 #[cfg(test)]
 mod test_serde {
-    use alloc::borrow::Cow::Borrowed;
+    use crate::models::amount::XRPAmount;
 
     use super::*;
 
@@ -168,8 +169,8 @@ mod test_serde {
         let default_txn = CheckCreate::new(
             "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
             "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy",
-            Amount::Xrp(Borrowed("100000000")),
-            Some("12"),
+            Amount::XRPAmount(XRPAmount::from("100000000")),
+            Some("12".into()),
             None,
             None,
             None,
@@ -196,8 +197,8 @@ mod test_serde {
         let default_txn = CheckCreate::new(
             "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
             "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy",
-            Amount::Xrp(Borrowed("100000000")),
-            Some("12"),
+            Amount::XRPAmount(XRPAmount::from("100000000")),
+            Some("12".into()),
             None,
             None,
             None,

--- a/src/models/transactions/deposit_preauth.rs
+++ b/src/models/transactions/deposit_preauth.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{
     exceptions::{DepositPreauthException, XRPLModelException, XRPLTransactionException},
     model::Model,
@@ -33,7 +34,7 @@ pub struct DepositPreauth<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -136,7 +137,7 @@ impl<'a> DepositPreauthError for DepositPreauth<'a> {
 impl<'a> DepositPreauth<'a> {
     fn new(
         account: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -223,7 +224,7 @@ mod test_serde {
     fn test_serialize() {
         let default_txn = DepositPreauth::new(
             "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
-            Some("10"),
+            Some("10".into()),
             Some(2),
             None,
             None,
@@ -248,7 +249,7 @@ mod test_serde {
     fn test_deserialize() {
         let default_txn = DepositPreauth::new(
             "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
-            Some("10"),
+            Some("10".into()),
             Some(2),
             None,
             None,

--- a/src/models/transactions/escrow_cancel.rs
+++ b/src/models/transactions/escrow_cancel.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// Cancels an Escrow and returns escrowed XRP to the sender.
@@ -28,7 +29,7 @@ pub struct EscrowCancel<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -112,7 +113,7 @@ impl<'a> EscrowCancel<'a> {
         account: &'a str,
         owner: &'a str,
         offer_sequence: u32,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,

--- a/src/models/transactions/escrow_create.rs
+++ b/src/models/transactions/escrow_create.rs
@@ -2,10 +2,11 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{
     exceptions::{EscrowCreateException, XRPLModelException, XRPLTransactionException},
     model::Model,
-    Amount, EscrowCreateError, Memo, Signer, Transaction, TransactionType,
+    EscrowCreateError, Memo, Signer, Transaction, TransactionType,
 };
 
 /// Creates an Escrow, which sequests XRP until the escrow process either finishes or is canceled.
@@ -32,7 +33,7 @@ pub struct EscrowCreate<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -77,7 +78,7 @@ pub struct EscrowCreate<'a> {
     ///
     /// See EscrowCreate fields:
     /// `<https://xrpl.org/escrowcreate.html#escrowcreate-flags>`
-    pub amount: Amount,
+    pub amount: XRPAmount<'a>,
     pub destination: &'a str,
     pub destination_tag: Option<u32>,
     pub cancel_after: Option<u32>,
@@ -148,9 +149,9 @@ impl<'a> EscrowCreateError for EscrowCreate<'a> {
 impl<'a> EscrowCreate<'a> {
     fn new(
         account: &'a str,
-        amount: Amount,
+        amount: XRPAmount<'a>,
         destination: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -193,10 +194,10 @@ impl<'a> EscrowCreate<'a> {
 mod test_escrow_create_errors {
     use crate::models::{
         exceptions::{EscrowCreateException, XRPLModelException, XRPLTransactionException},
-        Amount, Model, TransactionType,
+        Model, TransactionType,
     };
 
-    use alloc::borrow::Cow;
+    use crate::models::amount::XRPAmount;
 
     use super::EscrowCreate;
 
@@ -216,7 +217,7 @@ mod test_escrow_create_errors {
             flags: None,
             memos: None,
             signers: None,
-            amount: Amount::Xrp(Cow::Borrowed("100000000")),
+            amount: XRPAmount::from("100000000"),
             destination: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
             destination_tag: None,
             cancel_after: Some(13298498),
@@ -234,13 +235,12 @@ mod test_escrow_create_errors {
 #[cfg(test)]
 mod test_serde {
     use super::*;
-    use alloc::borrow::Cow::Borrowed;
 
     #[test]
     fn test_serialize() {
         let default_txn = EscrowCreate::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Amount::Xrp(Borrowed("10000")),
+            XRPAmount::from("10000"),
             "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
             None,
             None,
@@ -269,7 +269,7 @@ mod test_serde {
     fn test_deserialize() {
         let default_txn = EscrowCreate::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Amount::Xrp(Borrowed("10000")),
+            XRPAmount::from("10000"),
             "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
             None,
             None,

--- a/src/models/transactions/escrow_finish.rs
+++ b/src/models/transactions/escrow_finish.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{
     exceptions::{EscrowFinishException, XRPLModelException, XRPLTransactionException},
     model::Model,
@@ -32,7 +33,7 @@ pub struct EscrowFinish<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -140,7 +141,7 @@ impl<'a> EscrowFinish<'a> {
         account: &'a str,
         owner: &'a str,
         offer_sequence: u32,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,

--- a/src/models/transactions/nftoken_burn.rs
+++ b/src/models/transactions/nftoken_burn.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// Removes a NFToken object from the NFTokenPage in which it is being held,
@@ -29,7 +30,7 @@ pub struct NFTokenBurn<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -113,7 +114,7 @@ impl<'a> NFTokenBurn<'a> {
     fn new(
         account: &'a str,
         nftoken_id: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -154,7 +155,7 @@ mod test_serde {
         let default_txn = NFTokenBurn::new(
             "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
             "000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65",
-            Some("10"),
+            Some("10".into()),
             None,
             None,
             None,
@@ -179,7 +180,7 @@ mod test_serde {
         let default_txn = NFTokenBurn::new(
             "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
             "000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65",
-            Some("10"),
+            Some("10".into()),
             None,
             None,
             None,

--- a/src/models/transactions/nftoken_cancel_offer.rs
+++ b/src/models/transactions/nftoken_cancel_offer.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{
     exceptions::{NFTokenCancelOfferException, XRPLModelException, XRPLTransactionException},
     model::Model,
@@ -32,7 +33,7 @@ pub struct NFTokenCancelOffer<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -134,7 +135,7 @@ impl<'a> NFTokenCancelOffer<'a> {
     fn new(
         account: &'a str,
         nftoken_offers: Vec<&'a str>,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,

--- a/src/models/transactions/nftoken_create_offer.rs
+++ b/src/models/transactions/nftoken_create_offer.rs
@@ -1,4 +1,6 @@
 use alloc::vec::Vec;
+use core::convert::TryInto;
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
@@ -11,7 +13,7 @@ use crate::models::{
 };
 
 use crate::_serde::txn_flags;
-use crate::models::amount::{Amount, ValueAsDecimal, XRPAmount};
+use crate::models::amount::{Amount, XRPAmount};
 
 /// Transactions of the NFTokenCreateOffer type support additional values
 /// in the Flags field. This enum represents those options.
@@ -182,10 +184,11 @@ impl<'a> Transaction for NFTokenCreateOffer<'a> {
 
 impl<'a> NFTokenCreateOfferError for NFTokenCreateOffer<'a> {
     fn _get_amount_error(&self) -> Result<(), NFTokenCreateOfferException> {
+        // TODO: handle `rust_decimal` error
+        let amount: Decimal = self.amount.clone().try_into().unwrap();
         match !self.has_flag(&Flag::NFTokenCreateOffer(
             NFTokenCreateOfferFlag::TfSellOffer,
-            // TODO: handle `as_decimal` error
-        )) && self.amount.as_decimal().unwrap().is_zero()
+        )) && amount.is_zero()
         {
             true => Err(NFTokenCreateOfferException::InvalidAmountMustBeGreaterZero),
             false => Ok(()),

--- a/src/models/transactions/nftoken_mint.rs
+++ b/src/models/transactions/nftoken_mint.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 use crate::_serde::txn_flags;
+use crate::models::amount::XRPAmount;
 
 /// Transactions of the NFTokenMint type support additional values
 /// in the Flags field. This enum represents those options.
@@ -62,7 +63,7 @@ pub struct NFTokenMint<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -227,7 +228,7 @@ impl<'a> NFTokenMint<'a> {
     fn new(
         account: &'a str,
         nftoken_taxon: u32,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -374,7 +375,7 @@ mod test_serde {
         let default_txn = NFTokenMint::new(
             "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
             0,
-            Some("10"),
+            Some("10".into()),
             None,
             None,
             None,
@@ -402,7 +403,7 @@ mod test_serde {
         let default_txn = NFTokenMint::new(
             "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
             0,
-            Some("10"),
+            Some("10".into()),
             None,
             None,
             None,

--- a/src/models/transactions/offer_cancel.rs
+++ b/src/models/transactions/offer_cancel.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// Removes an Offer object from the XRP Ledger.
@@ -28,7 +29,7 @@ pub struct OfferCancel<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -109,7 +110,7 @@ impl<'a> OfferCancel<'a> {
     fn new(
         account: &'a str,
         offer_sequence: u32,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -148,7 +149,7 @@ mod test_serde {
         let default_txn = OfferCancel::new(
             "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
             6,
-            Some("12"),
+            Some("12".into()),
             Some(7),
             Some(7108629),
             None,
@@ -172,7 +173,7 @@ mod test_serde {
         let default_txn = OfferCancel::new(
             "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
             6,
-            Some("12"),
+            Some("12".into()),
             Some(7),
             Some(7108629),
             None,

--- a/src/models/transactions/payment.rs
+++ b/src/models/transactions/payment.rs
@@ -5,12 +5,14 @@ use serde_with::skip_serializing_none;
 use strum_macros::{AsRefStr, Display, EnumIter};
 
 use crate::models::{
+    amount::Amount,
     exceptions::{PaymentException, XRPLModelException, XRPLTransactionException},
     model::Model,
-    Amount, Flag, Memo, PathStep, PaymentError, Signer, Transaction, TransactionType,
+    Flag, Memo, PathStep, PaymentError, Signer, Transaction, TransactionType,
 };
 
 use crate::_serde::txn_flags;
+use crate::models::amount::XRPAmount;
 
 /// Transactions of the Payment type support additional values
 /// in the Flags field. This enum represents those options.
@@ -60,7 +62,7 @@ pub struct Payment<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -107,13 +109,13 @@ pub struct Payment<'a> {
     ///
     /// See Payment fields:
     /// `<https://xrpl.org/payment.html#payment-fields>`
-    pub amount: Amount,
+    pub amount: Amount<'a>,
     pub destination: &'a str,
     pub destination_tag: Option<u32>,
     pub invoice_id: Option<u32>,
     pub paths: Option<Vec<Vec<PathStep<'a>>>>,
-    pub send_max: Option<Amount>,
-    pub deliver_min: Option<Amount>,
+    pub send_max: Option<Amount<'a>>,
+    pub deliver_min: Option<Amount<'a>>,
 }
 
 impl<'a> Default for Payment<'a> {
@@ -240,9 +242,9 @@ impl<'a> PaymentError for Payment<'a> {
 impl<'a> Payment<'a> {
     fn new(
         account: &'a str,
-        amount: Amount,
+        amount: Amount<'a>,
         destination: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -256,8 +258,8 @@ impl<'a> Payment<'a> {
         destination_tag: Option<u32>,
         invoice_id: Option<u32>,
         paths: Option<Vec<Vec<PathStep<'a>>>>,
-        send_max: Option<Amount>,
-        deliver_min: Option<Amount>,
+        send_max: Option<Amount<'a>>,
+        deliver_min: Option<Amount<'a>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::Payment,
@@ -286,12 +288,12 @@ impl<'a> Payment<'a> {
 
 #[cfg(test)]
 mod test_payment_error {
-    use alloc::{borrow::Cow, vec};
-
+    use crate::models::amount::{Amount, IssuedCurrencyAmount, XRPAmount};
     use crate::models::{
         exceptions::{PaymentException, XRPLModelException, XRPLTransactionException},
-        Amount, Model, PathStep, PaymentFlag, TransactionType,
+        Model, PathStep, PaymentFlag, TransactionType,
     };
+    use alloc::vec;
 
     use super::Payment;
 
@@ -311,7 +313,7 @@ mod test_payment_error {
             flags: None,
             memos: None,
             signers: None,
-            amount: Amount::Xrp(Cow::Borrowed("1000000")),
+            amount: Amount::XRPAmount(XRPAmount::from("1000000")),
             destination: "rLSn6Z3T8uCxbcd1oxwfGQN1Fdn5CyGujK",
             destination_tag: None,
             invoice_id: None,
@@ -332,7 +334,7 @@ mod test_payment_error {
         assert_eq!(payment.validate(), Err(expected_error));
 
         payment.paths = None;
-        payment.send_max = Some(Amount::Xrp(Cow::Borrowed("99999")));
+        payment.send_max = Some(Amount::XRPAmount(XRPAmount::from("99999")));
         let expected_error =
             XRPLModelException::XRPLTransactionError(XRPLTransactionException::PaymentError(
                 PaymentException::InvalidSendMaxMustNotBeSetForXRPtoXRPNonPartialPayments,
@@ -364,7 +366,7 @@ mod test_payment_error {
             flags: None,
             memos: None,
             signers: None,
-            amount: Amount::Xrp(Cow::Borrowed("1000000")),
+            amount: Amount::XRPAmount("1000000".into()),
             destination: "rLSn6Z3T8uCxbcd1oxwfGQN1Fdn5CyGujK",
             destination_tag: None,
             invoice_id: None,
@@ -380,7 +382,7 @@ mod test_payment_error {
         assert_eq!(payment.validate(), Err(expected_error));
 
         payment.flags = None;
-        payment.deliver_min = Some(Amount::Xrp(Cow::Borrowed("99999")));
+        payment.deliver_min = Some(Amount::XRPAmount("99999".into()));
         let expected_error =
             XRPLModelException::XRPLTransactionError(XRPLTransactionException::PaymentError(
                 PaymentException::InvalidDeliverMinMustNotBeSetForNonPartialPayments,
@@ -404,11 +406,11 @@ mod test_payment_error {
             flags: None,
             memos: None,
             signers: None,
-            amount: Amount::IssuedCurrency {
-                value: Cow::Borrowed("10"),
-                currency: Cow::Borrowed("USD"),
-                issuer: Cow::Borrowed("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"),
-            },
+            amount: Amount::IssuedCurrencyAmount(IssuedCurrencyAmount::new(
+                "USD".into(),
+                "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B".into(),
+                "10".into(),
+            )),
             destination: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
             destination_tag: None,
             invoice_id: None,
@@ -428,7 +430,7 @@ mod test_payment_error {
 mod test_serde {
     use alloc::vec;
 
-    use crate::models::Amount;
+    use crate::models::amount::{Amount, IssuedCurrencyAmount};
 
     use super::*;
 
@@ -436,13 +438,13 @@ mod test_serde {
     fn test_serialize() {
         let default_txn = Payment::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Amount::IssuedCurrency {
-                currency: "USD".into(),
-                issuer: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
-                value: "1".into(),
-            },
+            Amount::IssuedCurrencyAmount(IssuedCurrencyAmount::new(
+                "USD".into(),
+                "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+                "1".into(),
+            )),
             "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            Some("12"),
+            Some("12".into()),
             Some(2),
             None,
             None,
@@ -471,13 +473,13 @@ mod test_serde {
     fn test_deserialize() {
         let default_txn = Payment::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Amount::IssuedCurrency {
-                currency: "USD".into(),
-                issuer: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
-                value: "1".into(),
-            },
+            Amount::IssuedCurrencyAmount(IssuedCurrencyAmount::new(
+                "USD".into(),
+                "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+                "1".into(),
+            )),
             "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            Some("12"),
+            Some("12".into()),
             Some(2),
             None,
             None,

--- a/src/models/transactions/payment_channel_claim.rs
+++ b/src/models/transactions/payment_channel_claim.rs
@@ -7,6 +7,7 @@ use strum_macros::{AsRefStr, Display, EnumIter};
 use crate::models::{model::Model, Flag, Memo, Signer, Transaction, TransactionType};
 
 use crate::_serde::txn_flags;
+use crate::models::amount::XRPAmount;
 
 /// Transactions of the PaymentChannelClaim type support additional values
 /// in the Flags field. This enum represents those options.
@@ -60,7 +61,7 @@ pub struct PaymentChannelClaim<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -173,7 +174,7 @@ impl<'a> PaymentChannelClaim<'a> {
     fn new(
         account: &'a str,
         channel: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,

--- a/src/models/transactions/payment_channel_create.rs
+++ b/src/models/transactions/payment_channel_create.rs
@@ -2,7 +2,8 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::models::{model::Model, Amount, Memo, Signer, Transaction, TransactionType};
+use crate::models::amount::XRPAmount;
+use crate::models::{model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// Create a unidirectional channel and fund it with XRP.
 ///
@@ -28,7 +29,7 @@ pub struct PaymentChannelCreate<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -73,7 +74,7 @@ pub struct PaymentChannelCreate<'a> {
     ///
     /// See PaymentChannelCreate fields:
     /// `<https://xrpl.org/paymentchannelcreate.html#paymentchannelcreate-fields>`
-    pub amount: Amount,
+    pub amount: XRPAmount<'a>,
     pub destination: &'a str,
     pub settle_delay: u32,
     pub public_key: &'a str,
@@ -118,11 +119,11 @@ impl<'a> Transaction for PaymentChannelCreate<'a> {
 impl<'a> PaymentChannelCreate<'a> {
     fn new(
         account: &'a str,
-        amount: Amount,
+        amount: XRPAmount<'a>,
         destination: &'a str,
         settle_delay: u32,
         public_key: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -167,7 +168,7 @@ mod test_serde {
     fn test_serialize() {
         let default_txn = PaymentChannelCreate::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Amount::Xrp(alloc::borrow::Cow::Borrowed("10000")),
+            XRPAmount::from("10000"),
             "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
             86400,
             "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
@@ -196,7 +197,7 @@ mod test_serde {
     fn test_deserialize() {
         let default_txn = PaymentChannelCreate::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Amount::Xrp(alloc::borrow::Cow::Borrowed("10000")),
+            XRPAmount::from("10000"),
             "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
             86400,
             "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",

--- a/src/models/transactions/payment_channel_fund.rs
+++ b/src/models/transactions/payment_channel_fund.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::models::{model::Model, Amount, Memo, Signer, Transaction, TransactionType};
+use crate::models::{amount::XRPAmount, model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// Add additional XRP to an open payment channel,
 /// and optionally update the expiration time of the channel.
@@ -29,7 +29,7 @@ pub struct PaymentChannelFund<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -74,7 +74,7 @@ pub struct PaymentChannelFund<'a> {
     ///
     /// See PaymentChannelFund fields:
     /// `<https://xrpl.org/paymentchannelfund.html#paymentchannelfund-fields>`
-    pub amount: Amount,
+    pub amount: XRPAmount<'a>,
     pub channel: &'a str,
     pub expiration: Option<u32>,
 }
@@ -114,8 +114,8 @@ impl<'a> PaymentChannelFund<'a> {
     fn new(
         account: &'a str,
         channel: &'a str,
-        amount: Amount,
-        fee: Option<&'a str>,
+        amount: XRPAmount<'a>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -150,7 +150,7 @@ impl<'a> PaymentChannelFund<'a> {
 
 #[cfg(test)]
 mod test_serde {
-    use crate::models::Amount;
+    use crate::models::amount::XRPAmount;
 
     use super::*;
 
@@ -159,7 +159,7 @@ mod test_serde {
         let default_txn = PaymentChannelFund::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
-            Amount::Xrp(alloc::borrow::Cow::Borrowed("200000")),
+            XRPAmount::from("200000"),
             None,
             None,
             None,
@@ -185,7 +185,7 @@ mod test_serde {
         let default_txn = PaymentChannelFund::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
-            Amount::Xrp(alloc::borrow::Cow::Borrowed("200000")),
+            XRPAmount::from("200000"),
             None,
             None,
             None,

--- a/src/models/transactions/pseudo_transactions/enable_amendment.rs
+++ b/src/models/transactions/pseudo_transactions/enable_amendment.rs
@@ -5,6 +5,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
 use strum_macros::{AsRefStr, Display, EnumIter};
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Flag, Transaction, TransactionType};
 
 #[derive(
@@ -42,7 +43,7 @@ pub struct EnableAmendment<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -103,7 +104,7 @@ impl<'a> EnableAmendment<'a> {
         account: &'a str,
         amendment: &'a str,
         ledger_sequence: u32,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         signing_pub_key: Option<&'a str>,
         source_tag: Option<u32>,

--- a/src/models/transactions/pseudo_transactions/set_fee.rs
+++ b/src/models/transactions/pseudo_transactions/set_fee.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Transaction, TransactionType};
 
 /// See SetFee:
@@ -25,7 +26,7 @@ pub struct SetFee<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -49,7 +50,7 @@ pub struct SetFee<'a> {
     ///
     /// See SetFee fields:
     /// `<https://xrpl.org/setfee.html#setfee-fields>`
-    pub base_fee: u64,
+    pub base_fee: XRPAmount<'a>,
     pub reference_fee_units: u32,
     pub reserve_base: u32,
     pub reserve_increment: u32,
@@ -67,12 +68,12 @@ impl<'a> Transaction for SetFee<'a> {
 impl<'a> SetFee<'a> {
     fn new(
         account: &'a str,
-        base_fee: u64,
+        base_fee: XRPAmount<'a>,
         reference_fee_units: u32,
         reserve_base: u32,
         reserve_increment: u32,
         ledger_sequence: u32,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         signing_pub_key: Option<&'a str>,
         source_tag: Option<u32>,

--- a/src/models/transactions/pseudo_transactions/unl_modify.rs
+++ b/src/models/transactions/pseudo_transactions/unl_modify.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{
     exceptions::{UNLModifyException, XRPLModelException, XRPLTransactionException},
     model::Model,
@@ -29,7 +30,7 @@ pub struct UNLModify<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -91,7 +92,7 @@ impl<'a> UNLModify<'a> {
         ledger_sequence: u32,
         unlmodify_disabling: u8,
         unlmodify_validator: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         signing_pub_key: Option<&'a str>,
         source_tag: Option<u32>,

--- a/src/models/transactions/set_regular_key.rs
+++ b/src/models/transactions/set_regular_key.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// You can protect your account by assigning a regular key pair to
@@ -32,7 +33,7 @@ pub struct SetRegularKey<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -112,7 +113,7 @@ impl<'a> Transaction for SetRegularKey<'a> {
 impl<'a> SetRegularKey<'a> {
     fn new(
         account: &'a str,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -151,7 +152,7 @@ mod test_serde {
     fn test_serialize() {
         let default_txn = SetRegularKey::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Some("12"),
+            Some("12".into()),
             None,
             None,
             None,
@@ -175,7 +176,7 @@ mod test_serde {
     fn test_deserialize() {
         let default_txn = SetRegularKey::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            Some("12"),
+            Some("12".into()),
             None,
             None,
             None,

--- a/src/models/transactions/signer_list_set.rs
+++ b/src/models/transactions/signer_list_set.rs
@@ -6,6 +6,7 @@ use derive_new::new;
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::{
     models::{
         exceptions::{SignerListSetException, XRPLModelException, XRPLTransactionException},
@@ -51,7 +52,7 @@ pub struct SignerListSet<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -203,7 +204,7 @@ impl<'a> SignerListSet<'a> {
     fn new(
         account: &'a str,
         signer_quorum: u32,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -415,7 +416,7 @@ mod test_serde {
         let default_txn = SignerListSet::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             3,
-            Some("12"),
+            Some("12".into()),
             None,
             None,
             None,
@@ -444,7 +445,7 @@ mod test_serde {
         let default_txn = SignerListSet::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             3,
-            Some("12"),
+            Some("12".into()),
             None,
             None,
             None,

--- a/src/models/transactions/ticket_create.rs
+++ b/src/models/transactions/ticket_create.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::models::amount::XRPAmount;
 use crate::models::{model::Model, Memo, Signer, Transaction, TransactionType};
 
 /// Sets aside one or more sequence numbers as Tickets.
@@ -28,7 +29,7 @@ pub struct TicketCreate<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -109,7 +110,7 @@ impl<'a> TicketCreate<'a> {
     fn new(
         account: &'a str,
         ticket_count: u32,
-        fee: Option<&'a str>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -148,7 +149,7 @@ mod test_serde {
         let default_txn = TicketCreate::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             10,
-            Some("10"),
+            Some("10".into()),
             Some(381),
             None,
             None,
@@ -172,7 +173,7 @@ mod test_serde {
         let default_txn = TicketCreate::new(
             "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             10,
-            Some("10"),
+            Some("10".into()),
             Some(381),
             None,
             None,

--- a/src/models/transactions/trust_set.rs
+++ b/src/models/transactions/trust_set.rs
@@ -4,9 +4,10 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
 use strum_macros::{AsRefStr, Display, EnumIter};
 
-use crate::models::{model::Model, Amount, Flag, Memo, Signer, Transaction, TransactionType};
+use crate::models::{model::Model, Flag, Memo, Signer, Transaction, TransactionType};
 
 use crate::_serde::txn_flags;
+use crate::models::amount::{IssuedCurrencyAmount, XRPAmount};
 
 /// Transactions of the TrustSet type support additional values
 /// in the Flags field. This enum represents those options.
@@ -55,7 +56,7 @@ pub struct TrustSet<'a> {
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
     /// See Transaction Cost for details.
-    pub fee: Option<&'a str>,
+    pub fee: Option<XRPAmount<'a>>,
     /// The sequence number of the account sending the transaction.
     /// A transaction is only valid if the Sequence number is exactly
     /// 1 greater than the previous transaction from the same account.
@@ -102,7 +103,7 @@ pub struct TrustSet<'a> {
     ///
     /// See TrustSet fields:
     /// `<https://xrpl.org/trustset.html#trustset-fields>`
-    pub limit_amount: Amount,
+    pub limit_amount: IssuedCurrencyAmount<'a>,
     pub quality_in: Option<u32>,
     pub quality_out: Option<u32>,
 }
@@ -160,8 +161,8 @@ impl<'a> Transaction for TrustSet<'a> {
 impl<'a> TrustSet<'a> {
     fn new(
         account: &'a str,
-        limit_amount: Amount,
-        fee: Option<&'a str>,
+        limit_amount: IssuedCurrencyAmount<'a>,
+        fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
         account_txn_id: Option<&'a str>,
@@ -199,18 +200,18 @@ impl<'a> TrustSet<'a> {
 #[cfg(test)]
 mod test_serde {
     use super::*;
-    use alloc::{borrow::Cow::Borrowed, vec};
+    use alloc::vec;
 
     #[test]
     fn test_serialize() {
         let default_txn = TrustSet::new(
             "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            Amount::IssuedCurrency {
-                currency: Borrowed("USD"),
-                issuer: Borrowed("rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"),
-                value: Borrowed("100"),
-            },
-            Some("12"),
+            IssuedCurrencyAmount::new(
+                "USD".into(),
+                "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc".into(),
+                "100".into(),
+            ),
+            Some("12".into()),
             Some(12),
             Some(8007750),
             None,
@@ -236,12 +237,12 @@ mod test_serde {
     fn test_deserialize() {
         let default_txn = TrustSet::new(
             "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            Amount::IssuedCurrency {
-                currency: Borrowed("USD"),
-                issuer: Borrowed("rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc"),
-                value: Borrowed("100"),
-            },
-            Some("12"),
+            IssuedCurrencyAmount::new(
+                "USD".into(),
+                "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc".into(),
+                "100".into(),
+            ),
+            Some("12".into()),
             Some(12),
             Some(8007750),
             None,


### PR DESCRIPTION
This is a follow up #55 

## High Level Overview of Change

This PR allows us to make our models stronger typed. It adds the following models:
- `Currency`
  - `IssuedCurrency`
  - `XRP`
- `Amount`
  - `IssuedCurrencyAmount`
  - `XRPAmount`

`Amounts` can be turned into `Currencies` and vice versa.
The `value` can be easily turned into `Decimal` using the `TryInto` trait (error handling still has to be implemented).

### Context of Change

https://github.com/sephynox/xrpl-rust/pull/55#issuecomment-1474174141

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

The currencies and amounts are tested in the tests for the models.

## Future Tasks
- [ ] Add exceptions as soon as #54 was merged.
