### PR TITLE
Fix todo

### DIFF
--- a/src/_serde/mod.rs
+++ b/src/_serde/mod.rs
@@ -5,6 +5,8 @@ use fnv::FnvHasher;
 
 pub type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasherDefault<FnvHasher>>;
 
+/// A `mod` to be used on transaction `flags` fields. It serializes the `Vec<Flag>` into a `u32`,
+/// representing the bit-flags, and deserializes the `u32` back into `Vec<Flag>` for internal uses.
 pub mod txn_flags {
     use core::fmt::Debug;
 
@@ -54,9 +56,16 @@ pub mod txn_flags {
     }
 }
 
-/// Source: https://github.com/serde-rs/serde/issues/554#issuecomment-249211775
+
+/// A macro to tag a struct externally. With `serde` attributes, unfortunately it is not possible to
+/// serialize a struct to json with its name as `key` and its fields as `value`. Example:
+/// `{"Example":{"Field1":"hello","Field2":"world"}}`
+///
+/// Several models need to be serialized in that format. This macro uses a helper to serialize and
+/// deserialize to/from that format.
+///
+/// Resource: https://github.com/serde-rs/serde/issues/554#issuecomment-249211775
 // TODO: Find a way to `#[skip_serializing_none]`
-// TODO: Find a more generic way
 #[macro_export]
 macro_rules! serde_with_tag {
     (

--- a/src/_serde/mod.rs
+++ b/src/_serde/mod.rs
@@ -56,7 +56,6 @@ pub mod txn_flags {
     }
 }
 
-
 /// A macro to tag a struct externally. With `serde` attributes, unfortunately it is not possible to
 /// serialize a struct to json with its name as `key` and its fields as `value`. Example:
 /// `{"Example":{"Field1":"hello","Field2":"world"}}`

--- a/src/models/amount/exceptions.rs
+++ b/src/models/amount/exceptions.rs
@@ -1,0 +1,10 @@
+use thiserror_no_std::Error;
+
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum XRPLAmountException {
+    #[error("Unable to convert amount `value` into `Decimal`.")]
+    ToDecimalError(#[from] rust_decimal::Error),
+}
+
+#[cfg(feature = "std")]
+impl alloc::error::Error for XRPLAmountException {}

--- a/src/models/amount/issued_currency_amount.rs
+++ b/src/models/amount/issued_currency_amount.rs
@@ -1,3 +1,4 @@
+use crate::models::amount::exceptions::XRPLAmountException;
 use crate::models::Model;
 use alloc::borrow::Cow;
 use core::convert::TryInto;
@@ -25,9 +26,12 @@ impl<'a> IssuedCurrencyAmount<'a> {
 }
 
 impl<'a> TryInto<Decimal> for IssuedCurrencyAmount<'a> {
-    type Error = rust_decimal::Error;
+    type Error = XRPLAmountException;
 
     fn try_into(self) -> Result<Decimal, Self::Error> {
-        Decimal::from_str(&self.value)
+        match Decimal::from_str(&self.value) {
+            Ok(decimal) => Ok(decimal),
+            Err(decimal_error) => Err(XRPLAmountException::ToDecimalError(decimal_error)),
+        }
     }
 }

--- a/src/models/amount/mod.rs
+++ b/src/models/amount/mod.rs
@@ -1,11 +1,13 @@
+pub mod exceptions;
 pub mod issued_currency_amount;
 pub mod xrp_amount;
 
 use core::convert::TryInto;
 pub use issued_currency_amount::*;
-use rust_decimal::{Decimal, Error};
+use rust_decimal::Decimal;
 pub use xrp_amount::*;
 
+use crate::models::amount::exceptions::XRPLAmountException;
 use crate::models::Model;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
@@ -18,7 +20,7 @@ pub enum Amount<'a> {
 }
 
 impl<'a> TryInto<Decimal> for Amount<'a> {
-    type Error = Error;
+    type Error = XRPLAmountException;
 
     fn try_into(self) -> Result<Decimal, Self::Error> {
         match self {

--- a/src/models/amount/xrp_amount.rs
+++ b/src/models/amount/xrp_amount.rs
@@ -1,3 +1,4 @@
+use crate::models::amount::exceptions::XRPLAmountException;
 use crate::models::Model;
 use alloc::borrow::Cow;
 use core::convert::TryInto;
@@ -23,9 +24,12 @@ impl<'a> From<&'a str> for XRPAmount<'a> {
 }
 
 impl<'a> TryInto<Decimal> for XRPAmount<'a> {
-    type Error = rust_decimal::Error;
+    type Error = XRPLAmountException;
 
     fn try_into(self) -> Result<Decimal, Self::Error> {
-        Decimal::from_str(&self.0)
+        match Decimal::from_str(&self.0) {
+            Ok(decimal) => Ok(decimal),
+            Err(decimal_error) => Err(XRPLAmountException::ToDecimalError(decimal_error)),
+        }
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -25,8 +25,9 @@ use crate::models::transactions::{
     XRPLAccountSetException, XRPLCheckCashException, XRPLDepositPreauthException,
     XRPLEscrowCreateException, XRPLEscrowFinishException, XRPLNFTokenAcceptOfferException,
     XRPLNFTokenCancelOfferException, XRPLNFTokenCreateOfferException, XRPLNFTokenMintException,
-    XRPLPaymentException, XRPLSignerListSetException, XRPLUNLModifyException,
+    XRPLPaymentException, XRPLSignerListSetException,
 };
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use strum_macros::AsRefStr;
@@ -416,7 +417,7 @@ pub trait EscrowFinishError {
 
 pub trait NFTokenAcceptOfferError {
     fn _get_brokered_mode_error(&self) -> Result<(), XRPLNFTokenAcceptOfferException>;
-    fn _get_nftoken_broker_fee_error(&self) -> Result<(), XRPLNFTokenAcceptOfferException>;
+    fn _get_nftoken_broker_fee_error(&self) -> Result<()>;
 }
 
 pub trait NFTokenCancelOfferError {
@@ -424,7 +425,7 @@ pub trait NFTokenCancelOfferError {
 }
 
 pub trait NFTokenCreateOfferError {
-    fn _get_amount_error(&self) -> Result<(), XRPLNFTokenCreateOfferException>;
+    fn _get_amount_error(&self) -> Result<()>;
     fn _get_destination_error(&self) -> Result<(), XRPLNFTokenCreateOfferException>;
     fn _get_owner_error(&self) -> Result<(), XRPLNFTokenCreateOfferException>;
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -446,10 +446,6 @@ pub trait SignerListSetError {
     fn _get_signer_quorum_error(&self) -> Result<(), XRPLSignerListSetException>;
 }
 
-pub trait UNLModifyError {
-    fn _get_unl_modify_error(&self) -> Result<(), XRPLUNLModifyException>;
-}
-
 pub trait ChannelAuthorizeError {
     fn _get_field_error(&self) -> Result<(), XRPLChannelAuthorizeException>;
 }

--- a/src/models/requests/submit_multisigned.rs
+++ b/src/models/requests/submit_multisigned.rs
@@ -17,9 +17,6 @@ use crate::models::{Model, RequestMethod};
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct SubmitMultisigned<'a> {
-    // TODO
-    // #[serde(rename(serialize = "tx_json", deserialize = "transaction"))]
-    // transaction,
     /// The unique request id.
     pub id: Option<&'a str>,
     /// If true, and the transaction fails locally, do not

--- a/src/models/requests/subscribe.rs
+++ b/src/models/requests/subscribe.rs
@@ -10,7 +10,7 @@ use crate::models::{currency::Currency, default_false, Model, RequestMethod, Str
 /// `<https://xrpl.org/subscribe.html#subscribe>`
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
-pub struct Book<'a> {
+pub struct SubscribeBook<'a> {
     pub taker_gets: Currency<'a>,
     pub taker_pays: Currency<'a>,
     pub taker: &'a str,
@@ -34,7 +34,7 @@ pub struct Subscribe<'a> {
     pub id: Option<&'a str>,
     /// Array of objects defining order books  to monitor for
     /// updates, as detailed below.
-    pub books: Option<Vec<Book<'a>>>,
+    pub books: Option<Vec<SubscribeBook<'a>>>,
     /// Array of string names of generic streams to subscribe to.
     pub streams: Option<Vec<StreamParameter>>,
     /// Array with the unique addresses of accounts to monitor
@@ -79,7 +79,7 @@ impl<'a> Model for Subscribe<'a> {}
 impl<'a> Subscribe<'a> {
     fn new(
         id: Option<&'a str>,
-        books: Option<Vec<Book<'a>>>,
+        books: Option<Vec<SubscribeBook<'a>>>,
         streams: Option<Vec<StreamParameter>>,
         accounts: Option<Vec<&'a str>>,
         accounts_proposed: Option<Vec<&'a str>>,

--- a/src/models/requests/tx.rs
+++ b/src/models/requests/tx.rs
@@ -10,9 +10,6 @@ use crate::models::{Model, RequestMethod};
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Tx<'a> {
-    // TODO
-    // #[serde(rename(serialize = "tx_json", deserialize = "transaction"))]
-    // transaction,
     /// The unique request id.
     pub id: Option<&'a str>,
     /// If true, return transaction data and metadata as binary

--- a/src/models/requests/unsubscribe.rs
+++ b/src/models/requests/unsubscribe.rs
@@ -10,7 +10,7 @@ use crate::models::{currency::Currency, default_false, Model, RequestMethod, Str
 /// `<https://xrpl.org/unsubscribe.html>`
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(serialize = "PascalCase", deserialize = "snake_case"))]
-pub struct Book<'a> {
+pub struct UnsubscribeBook<'a> {
     pub taker_gets: Currency<'a>,
     pub taker_pays: Currency<'a>,
     #[serde(default = "default_false")]
@@ -32,8 +32,7 @@ pub struct Unsubscribe<'a> {
     pub id: Option<&'a str>,
     /// Array of objects defining order books to unsubscribe
     /// from, as explained below.
-    // TODO: USE `UnsubscribeBookFields` AS SOON AS LIFETIME ISSUES ARE FIXED
-    pub books: Option<Vec<Book<'a>>>,
+    pub books: Option<Vec<UnsubscribeBook<'a>>>,
     /// Array of string names of generic streams to unsubscribe
     /// from, including ledger, server, transactions,
     /// and transactions_proposed.
@@ -47,7 +46,6 @@ pub struct Unsubscribe<'a> {
     /// Like accounts, but for accounts_proposed subscriptions that
     /// included not-yet-validated transactions.
     pub accounts_proposed: Option<Vec<&'a str>>,
-    // TODO Lifetime issue
     #[serde(skip_serializing)]
     pub broken: Option<&'a str>,
     /// The request method.
@@ -74,7 +72,7 @@ impl<'a> Model for Unsubscribe<'a> {}
 impl<'a> Unsubscribe<'a> {
     fn new(
         id: Option<&'a str>,
-        books: Option<Vec<Book<'a>>>,
+        books: Option<Vec<UnsubscribeBook<'a>>>,
         streams: Option<Vec<StreamParameter>>,
         accounts: Option<Vec<&'a str>>,
         accounts_proposed: Option<Vec<&'a str>>,

--- a/src/models/transactions/exceptions.rs
+++ b/src/models/transactions/exceptions.rs
@@ -15,7 +15,6 @@ pub enum XRPLTransactionException<'a> {
     XRPLNFTokenMintError(XRPLNFTokenMintException<'a>),
     XRPLPaymentError(XRPLPaymentException<'a>),
     XRPLSignerListSetError(XRPLSignerListSetException<'a>),
-    XRPLUNLModifyError(XRPLUNLModifyException<'a>),
 }
 
 #[cfg(feature = "std")]
@@ -327,18 +326,3 @@ pub enum XRPLSignerListSetException<'a> {
 
 #[cfg(feature = "std")]
 impl<'a> alloc::error::Error for XRPLSignerListSetException<'a> {}
-
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum XRPLUNLModifyException<'a> {
-    /// A field is expected to have a certain value.
-    #[error("The field `{field:?}` has an invalid value (expected {expected:?}, found {found:?}). For more information see: {resource:?}")]
-    InvalidValue {
-        field: &'a str,
-        expected: &'a str,
-        found: u32,
-        resource: &'a str,
-    },
-}
-
-#[cfg(feature = "std")]
-impl<'a> alloc::error::Error for XRPLUNLModifyException<'a> {}

--- a/src/models/transactions/nftoken_create_offer.rs
+++ b/src/models/transactions/nftoken_create_offer.rs
@@ -15,6 +15,7 @@ use crate::models::{
 
 use crate::Err;
 use crate::_serde::txn_flags;
+use crate::models::amount::exceptions::XRPLAmountException;
 use crate::models::amount::{Amount, XRPAmount};
 use crate::models::transactions::XRPLNFTokenCreateOfferException;
 
@@ -180,19 +181,26 @@ impl<'a> Transaction for NFTokenCreateOffer<'a> {
 }
 
 impl<'a> NFTokenCreateOfferError for NFTokenCreateOffer<'a> {
-    fn _get_amount_error(&self) -> Result<(), XRPLNFTokenCreateOfferException> {
-        // TODO: handle `rust_decimal` error
-        let amount: Decimal = self.amount.clone().try_into().unwrap();
-        if !self.has_flag(&Flag::NFTokenCreateOffer(
-            NFTokenCreateOfferFlag::TfSellOffer,
-        )) && amount.is_zero()
-        {
-            Err(XRPLNFTokenCreateOfferException::ValueZero {
-                field: "amount",
-                resource: "",
-            })
-        } else {
-            Ok(())
+    fn _get_amount_error(&self) -> Result<()> {
+        let amount_into_decimal: Result<Decimal, XRPLAmountException> =
+            self.amount.clone().try_into();
+        match amount_into_decimal {
+            Ok(amount) => {
+                if !self.has_flag(&Flag::NFTokenCreateOffer(
+                    NFTokenCreateOfferFlag::TfSellOffer,
+                )) && amount.is_zero()
+                {
+                    Err!(XRPLNFTokenCreateOfferException::ValueZero {
+                        field: "amount",
+                        resource: "",
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+            Err(decimal_error) => {
+                Err!(decimal_error)
+            }
         }
     }
 

--- a/src/models/transactions/pseudo_transactions/unl_modify.rs
+++ b/src/models/transactions/pseudo_transactions/unl_modify.rs
@@ -1,17 +1,9 @@
-use crate::Err;
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
 use strum_macros::{AsRefStr, Display, EnumIter};
 
-use alloc::string::ToString;
-
-use crate::models::transactions::XRPLUNLModifyException;
-use crate::models::{
-    amount::XRPAmount, model::Model, Transaction, TransactionType, UNLModifyError,
-};
-
+use crate::models::{amount::XRPAmount, model::Model, Transaction, TransactionType};
 
 #[derive(
     Debug, Eq, PartialEq, Clone, Serialize_repr, Deserialize_repr, Display, AsRefStr, EnumIter,
@@ -73,14 +65,7 @@ pub struct UNLModify<'a> {
     pub unlmodify_validator: &'a str,
 }
 
-impl<'a: 'static> Model for UNLModify<'a> {
-    fn get_errors(&self) -> Result<()> {
-        match self._get_unl_modify_error() {
-            Err(error) => Err!(error),
-            Ok(_no_error) => Ok(()),
-        }
-    }
-}
+impl<'a> Model for UNLModify<'a> {}
 
 impl<'a> Transaction for UNLModify<'a> {
     fn get_transaction_type(&self) -> TransactionType {

--- a/src/models/transactions/pseudo_transactions/unl_modify.rs
+++ b/src/models/transactions/pseudo_transactions/unl_modify.rs
@@ -1,7 +1,9 @@
 use crate::Err;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
+use strum_macros::{AsRefStr, Display, EnumIter};
 
 use alloc::string::ToString;
 
@@ -9,6 +11,16 @@ use crate::models::transactions::XRPLUNLModifyException;
 use crate::models::{
     amount::XRPAmount, model::Model, Transaction, TransactionType, UNLModifyError,
 };
+
+
+#[derive(
+    Debug, Eq, PartialEq, Clone, Serialize_repr, Deserialize_repr, Display, AsRefStr, EnumIter,
+)]
+#[repr(u32)]
+pub enum UNLModifyDisabling {
+    Disable = 0,
+    Enable = 1,
+}
 
 /// See UNLModify:
 /// `<https://xrpl.org/unlmodify.html>`
@@ -57,7 +69,7 @@ pub struct UNLModify<'a> {
     /// See UNLModify fields:
     /// `<https://xrpl.org/unlmodify.html#unlmodify-fields>`
     pub ledger_sequence: u32,
-    pub unlmodify_disabling: u8,
+    pub unlmodify_disabling: UNLModifyDisabling,
     pub unlmodify_validator: &'a str,
 }
 
@@ -76,28 +88,11 @@ impl<'a> Transaction for UNLModify<'a> {
     }
 }
 
-// TODO: Enum for unlmodify_disabling to make looking for error obsolete
-impl<'a> UNLModifyError for UNLModify<'a> {
-    fn _get_unl_modify_error(&self) -> Result<(), XRPLUNLModifyException> {
-        let possible_unlmodify_disabling: [u8; 2] = [0, 1];
-        if !possible_unlmodify_disabling.contains(&self.unlmodify_disabling) {
-            Err(XRPLUNLModifyException::InvalidValue {
-                field: "unlmodify_disabling",
-                expected: "0 or 1",
-                found: self.unlmodify_disabling as u32,
-                resource: "",
-            })
-        } else {
-            Ok(())
-        }
-    }
-}
-
 impl<'a> UNLModify<'a> {
     fn new(
         account: &'a str,
         ledger_sequence: u32,
-        unlmodify_disabling: u8,
+        unlmodify_disabling: UNLModifyDisabling,
         unlmodify_validator: &'a str,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
@@ -118,37 +113,5 @@ impl<'a> UNLModify<'a> {
             unlmodify_disabling,
             unlmodify_validator,
         }
-    }
-}
-
-#[cfg(test)]
-mod test_unl_modify_error {
-
-    use crate::models::{Model, TransactionType};
-    use alloc::string::ToString;
-
-    use super::UNLModify;
-
-    #[test]
-    fn test_unlmodify_disabling_error() {
-        let unl_modify = UNLModify {
-            transaction_type: TransactionType::UNLModify,
-            account: "",
-            fee: None,
-            sequence: None,
-            signing_pub_key: None,
-            source_tag: None,
-            txn_signature: None,
-            flags: None,
-            ledger_sequence: 1600000,
-            unlmodify_disabling: 3,
-            unlmodify_validator:
-                "ED6629D456285AE3613B285F65BBFF168D695BA3921F309949AFCD2CA7AFEC16FE",
-        };
-
-        assert_eq!(
-            unl_modify.validate().unwrap_err().to_string().as_str(),
-            "The field `unlmodify_disabling` has an invalid value (expected 0 or 1, found 3). For more information see: "
-        );
     }
 }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -21,24 +21,24 @@ use zeroize::Zeroize;
 struct Wallet {
     /// The seed from which the public and private keys
     /// are derived.
-    seed: String,
+    pub seed: String,
     /// The public key that is used to identify this wallet's
     /// signatures, as a hexadecimal string.
-    public_key: String,
+    pub public_key: String,
     /// The private key that is used to create signatures, as
     /// a hexadecimal string. MUST be kept secret!
     ///
     /// TODO Use seckey
-    private_key: String,
+    pub private_key: String,
     /// The address that publicly identifies this wallet, as
     /// a base58 string.
-    classic_address: String,
+    pub classic_address: String,
     /// The next available sequence number to use for
     /// transactions from this wallet. Must be updated by the
     /// user. Increments on the ledger with every successful
     /// transaction submission, and stays the same with every
     /// failed transaction submission.
-    sequence: u64,
+    pub sequence: u64,
 }
 
 // Zeroize the memory where sensitive data is stored.


### PR DESCRIPTION
## High Level Overview of Change

This PR simply resolves some `TODOs`.

- add some `_serde` documentation
- `subscribe` and `unsubscribe` both have an object called `Book` to clarify I've renamed it to `SubscribeBook` and `UnsubscribeBook`
- `UNLModify` has a field `unlmodify_disabling` which can only be `0` or `1`. Instead of being type `u8` I've added a enum `UNLModifyDisabling` making `UNLModifyError` obsolete.
- Added `XRPLAmountException` to handle `amount.try_into()` `Decimal` errors
- Make wallet fields public