### PR TITLE
Add AsyncWebsocketClient

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --no-default-features --features core,models
+          args: --release --no-default-features --features core,models,net,tungstenite
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -33,4 +33,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features core,models
+          args: --no-default-features --features core,models,net,tungstenite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples
   - Wallet from seed
   - New wallet generation
+  - `AsyncWebsocketClient` requests
 - make `new` methods of models public
+- add `AsyncWebsocketClient`
+- update dependencies
 
 ## [[v0.2.0-beta]]
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,14 @@ ed25519-dalek = "1.0.1"
 secp256k1 = { version = "0.27.0", default-features = false, features = [
     "alloc",
 ] }
-bs58 = { version = "0.4.0", default-features = false, features = [
+bs58 = { version = "0.5.0", default-features = false, features = [
     "check",
     "alloc",
 ] }
-indexmap = { version = "1.7.0", features = ["serde"] }
+indexmap = { version = "2.0.0", features = ["serde"] }
 regex = { version = "1.5.4", default-features = false }
-strum = { version = "0.24.1", default-features = false }
-strum_macros = { version = "0.24.2", default-features = false }
+strum = { version = "0.25.0", default-features = false }
+strum_macros = { version = "0.25.2", default-features = false }
 crypto-bigint = { version = "0.5.1" }
 rust_decimal = { version = "1.17.0", default-features = false, features = [
     "serde",
@@ -51,33 +51,63 @@ serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false, features = [
     "alloc",
 ] }
-serde_with = "2.3.1"
+serde_with = "3.2.0"
 serde_repr = "0.1"
 zeroize = "1.5.7"
-hashbrown = { version = "0.13.2", default-features = false, features = ["serde"] }
+hashbrown = { version = "0.14.0", default-features = false, features = ["serde"] }
 fnv = { version = "1.0.7", default-features = false }
 derive-new = { version = "0.5.9", default-features = false }
 thiserror-no-std = "2.0.2"
 anyhow = { version ="1.0.69", default-features = false }
+tokio = { version = "1.28.0", default-features = false, optional = true }
+url = { version = "2.2.2", default-features = false, optional = true }
+futures = { version = "0.3.28", default-features = false, optional = true }
+rand_core = { version = "0.6.4", default-features = false }
+tokio-tungstenite = { version = "0.20.0", optional = true }
+
+[dependencies.embedded-websocket]
+# git version needed to use `framer_async`
+git = "https://github.com/ninjasource/embedded-websocket"
+version = "0.9.2"
+rev = "8d87d46f46fa0c75e099ca8aad37e8d00c8854f8"
+default-features = false
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.5.1"
 cargo-husky = { version = "1.5.0", default-features = false, features = [
     "user-hooks",
 ] }
+tokio = { version = "1.28.2", features = ["full"] }
+tokio-util = { version = "0.7.7", features = ["codec"] }
+bytes = { version = "1.4.0", default-features = false }
 
 [[bench]]
 name = "benchmarks"
 harness = false
 
 [features]
-default = ["std", "core", "models", "utils"]
+default = ["std", "core", "models", "utils", "net", "tungstenite"]
 models = ["core", "transactions", "requests", "ledger"]
 transactions = ["core", "amounts", "currencies"]
 requests = ["core", "amounts", "currencies"]
 ledger = ["core", "amounts", "currencies"]
 amounts = ["core"]
 currencies = ["core"]
+net = ["url", "futures"]
+tungstenite = ["tokio/net", "tokio-tungstenite/native-tls"]
 core = ["utils"]
 utils = []
-std = ["rand/std", "regex/std", "chrono/std", "rand/std_rng", "hex/std", "rust_decimal/std", "bs58/std", "serde/std", "indexmap/std", "secp256k1/std"]
+std = [
+    "embedded-websocket/std",
+    "futures/std",
+    "rand/std",
+    "regex/std",
+    "chrono/std",
+    "rand/std_rng",
+    "hex/std",
+    "rust_decimal/std",
+    "bs58/std",
+    "serde/std",
+    "indexmap/std",
+    "secp256k1/std",
+]

--- a/examples/std/src/bin/tokio/net/send_request.rs
+++ b/examples/std/src/bin/tokio/net/send_request.rs
@@ -1,4 +1,32 @@
+use xrpl::asynch::client::{AsyncWebsocketClientTungstenite, TungsteniteMessage};
+use xrpl::models::requests::AccountInfo;
+
 // TODO: add as soon as `AsyncWebsocketClient` is implemented
-fn main() {
-    todo!()
+#[tokio::main]
+async fn main() {
+    let websocket =
+        AsyncWebsocketClientTungstenite::open("wss://xrplcluster.com/".parse().unwrap())
+            .await
+            .unwrap();
+    assert!(websocket.is_open());
+
+    let account_info = AccountInfo::new(
+        "rJumr5e1HwiuV543H7bqixhtFreChWTaHH",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    websocket.send(&account_info).await.unwrap();
+
+    while let Ok(Some(TungsteniteMessage::Text(response))) = websocket.try_next().await {
+        let account_info_echo: AccountInfo = serde_json::from_str(response.as_str()).unwrap();
+        println!("account_info_echo: {:?}", account_info_echo);
+
+        websocket.close().await.unwrap();
+        break;
+    }
 }

--- a/src/asynch/clients/async_websocket_client.rs
+++ b/src/asynch/clients/async_websocket_client.rs
@@ -1,0 +1,284 @@
+use super::exceptions::XRPLWebsocketException;
+use crate::Err;
+use alloc::string::ToString;
+use anyhow::Result;
+use core::{fmt::Debug, marker::PhantomData, ops::Deref};
+use embedded_websocket::{
+    framer_async::Framer as EmbeddedWebsocketFramer, Client as EmbeddedWebsocketClient,
+    WebSocket as EmbeddedWebsocket,
+};
+use futures::{Sink, Stream};
+use rand_core::RngCore;
+// Exports
+#[cfg(feature = "tungstenite")]
+pub use tungstenite::*;
+
+pub use embedded_websocket::{
+    framer_async::{
+        FramerError as EmbeddedWebsocketFramerError, ReadResult as EmbeddedWebsocketReadMessageType,
+    },
+    Error as EmbeddedWebsocketError, WebSocketCloseStatusCode as EmbeddedWebsocketCloseStatusCode,
+    WebSocketOptions as EmbeddedWebsocketOptions,
+    WebSocketSendMessageType as EmbeddedWebsocketSendMessageType,
+    WebSocketState as EmbeddedWebsocketState,
+};
+
+pub type AsyncWebsocketClientEmbeddedWebsocket<Rng, Status> =
+    AsyncWebsocketClient<EmbeddedWebsocketFramer<Rng, EmbeddedWebsocketClient>, Status>;
+
+pub struct WebsocketOpen;
+pub struct WebsocketClosed;
+
+pub struct AsyncWebsocketClient<T, Status = WebsocketClosed> {
+    inner: T,
+    status: PhantomData<Status>,
+}
+
+impl<T, Status> AsyncWebsocketClient<T, Status> {
+    pub fn is_open(&self) -> bool {
+        core::any::type_name::<Status>() == core::any::type_name::<WebsocketOpen>()
+    }
+}
+
+#[cfg(feature = "tungstenite")]
+mod tungstenite {
+    use super::*;
+    use core::fmt::Display;
+    use core::{pin::Pin, task::Poll};
+    use tokio::net::TcpStream;
+    pub use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
+    use tokio_tungstenite::{
+        connect_async as tungstenite_connect_async, MaybeTlsStream as TungsteniteMaybeTlsStream,
+        WebSocketStream as TungsteniteWebsocketStream,
+    };
+    use url::Url;
+
+    pub type AsyncWebsocketClientTungstenite<Status> = AsyncWebsocketClient<
+        TungsteniteWebsocketStream<TungsteniteMaybeTlsStream<TcpStream>>,
+        Status,
+    >;
+
+    impl<T, I> Sink<I> for AsyncWebsocketClient<T, WebsocketOpen>
+    where
+        T: Sink<TungsteniteMessage> + Unpin,
+        <T as Sink<TungsteniteMessage>>::Error: Display,
+        I: serde::Serialize,
+    {
+        type Error = anyhow::Error;
+
+        fn poll_ready(
+            mut self: core::pin::Pin<&mut Self>,
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<core::result::Result<(), Self::Error>> {
+            match Pin::new(&mut self.inner).poll_ready(cx) {
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+                Poll::Ready(Err(error)) => Poll::Ready(Err!(error)),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn start_send(
+            mut self: core::pin::Pin<&mut Self>,
+            item: I,
+        ) -> core::result::Result<(), Self::Error> {
+            match Pin::new(&mut self.inner).start_send(TungsteniteMessage::Text(
+                serde_json::to_string(&item).unwrap(),
+            )) {
+                // TODO: unwrap
+                Ok(()) => Ok(()),
+                Err(error) => Err!(error),
+            }
+        }
+
+        fn poll_flush(
+            mut self: core::pin::Pin<&mut Self>,
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<core::result::Result<(), Self::Error>> {
+            match Pin::new(&mut self.inner).poll_flush(cx) {
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+                Poll::Ready(Err(error)) => Poll::Ready(Err!(error)),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn poll_close(
+            mut self: core::pin::Pin<&mut Self>,
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<core::result::Result<(), Self::Error>> {
+            match Pin::new(&mut self.inner).poll_close(cx) {
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+                Poll::Ready(Err(error)) => Poll::Ready(Err!(error)),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    impl<T> Stream for AsyncWebsocketClient<T, WebsocketOpen>
+    where
+        T: Stream + Unpin,
+    {
+        type Item = <T as Stream>::Item;
+
+        fn poll_next(
+            mut self: Pin<&mut Self>,
+            cx: &mut core::task::Context<'_>,
+        ) -> Poll<Option<Self::Item>> {
+            match Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    impl
+        AsyncWebsocketClient<
+            TungsteniteWebsocketStream<TungsteniteMaybeTlsStream<TcpStream>>,
+            WebsocketClosed,
+        >
+    {
+        pub async fn open(
+            uri: Url,
+        ) -> Result<
+            AsyncWebsocketClient<
+                TungsteniteWebsocketStream<TungsteniteMaybeTlsStream<TcpStream>>,
+                WebsocketOpen,
+            >,
+        > {
+            let (websocket_stream, _) = tungstenite_connect_async(uri).await.unwrap(); // TODO: unwrap
+
+            Ok(AsyncWebsocketClient {
+                inner: websocket_stream,
+                status: PhantomData::<WebsocketOpen>,
+            })
+        }
+    }
+}
+
+impl<Rng>
+    AsyncWebsocketClient<EmbeddedWebsocketFramer<Rng, EmbeddedWebsocketClient>, WebsocketClosed>
+where
+    Rng: RngCore,
+{
+    pub async fn open<'a, B, E>(
+        stream: &mut (impl Stream<Item = Result<B, E>> + Sink<&'a [u8], Error = E> + Unpin),
+        buffer: &'a mut [u8],
+        rng: Rng,
+        websocket_options: &EmbeddedWebsocketOptions<'_>,
+    ) -> Result<
+        AsyncWebsocketClient<EmbeddedWebsocketFramer<Rng, EmbeddedWebsocketClient>, WebsocketOpen>,
+    >
+    where
+        B: AsRef<[u8]>,
+        E: Debug,
+    {
+        let websocket = EmbeddedWebsocket::<Rng, EmbeddedWebsocketClient>::new_client(rng);
+        let mut framer = EmbeddedWebsocketFramer::new(websocket);
+        framer
+            .connect(stream, buffer, websocket_options)
+            .await
+            .unwrap(); // TODO: unwrap
+
+        Ok(AsyncWebsocketClient {
+            inner: framer,
+            status: PhantomData::<WebsocketOpen>,
+        })
+    }
+}
+
+impl<Rng> AsyncWebsocketClient<EmbeddedWebsocketFramer<Rng, EmbeddedWebsocketClient>, WebsocketOpen>
+where
+    Rng: RngCore,
+{
+    pub fn encode<E>(
+        &mut self,
+        message_type: EmbeddedWebsocketSendMessageType,
+        end_of_message: bool,
+        from: &[u8],
+        to: &mut [u8],
+    ) -> Result<usize>
+    where
+        E: Debug,
+    {
+        let len = self
+            .inner
+            .encode::<E>(message_type, end_of_message, from, to)
+            .unwrap(); // TODO: unwrap
+
+        Ok(len)
+    }
+
+    pub async fn send<'b, E, R: serde::Serialize>(
+        &mut self,
+        stream: &mut (impl Sink<&'b [u8], Error = E> + Unpin),
+        stream_buf: &'b mut [u8],
+        end_of_message: bool,
+        frame_buf: R,
+    ) -> Result<()>
+    where
+        E: Debug,
+    {
+        self.inner
+            .write(
+                stream,
+                stream_buf,
+                EmbeddedWebsocketSendMessageType::Binary,
+                end_of_message,
+                serde_json::to_vec(&frame_buf).unwrap().as_slice(),
+            ) // TODO: unwrap
+            .await
+            .unwrap(); // TODO: unwrap
+
+        Ok(())
+    }
+
+    pub async fn close<'b, E>(
+        &mut self,
+        stream: &mut (impl Sink<&'b [u8], Error = E> + Unpin),
+        stream_buf: &'b mut [u8],
+        close_status: EmbeddedWebsocketCloseStatusCode,
+        status_description: Option<&str>,
+    ) -> Result<()>
+    where
+        E: Debug,
+    {
+        self.inner
+            .close(stream, stream_buf, close_status, status_description)
+            .await
+            .unwrap(); // TODO: unwrap
+
+        Ok(())
+    }
+
+    pub async fn next<'a, B: Deref<Target = [u8]>, E>(
+        &'a mut self,
+        stream: &mut (impl Stream<Item = Result<B, E>> + Sink<&'a [u8], Error = E> + Unpin),
+        buffer: &'a mut [u8],
+    ) -> Option<Result<EmbeddedWebsocketReadMessageType<'_>>>
+    // TODO: Change to Response as soon as implemented
+    where
+        E: Debug,
+    {
+        match self.inner.read(stream, buffer).await {
+            Some(Ok(read_result)) => Some(Ok(read_result)),
+            Some(Err(error)) => Some(Err!(XRPLWebsocketException::from(error))),
+            None => None,
+        }
+    }
+
+    pub async fn try_next<'a, B: Deref<Target = [u8]>, E>(
+        &'a mut self,
+        stream: &mut (impl Stream<Item = Result<B, E>> + Sink<&'a [u8], Error = E> + Unpin),
+        buffer: &'a mut [u8],
+    ) -> Result<Option<EmbeddedWebsocketReadMessageType<'_>>>
+    // TODO: Change to Response as soon as implemented
+    where
+        E: Debug,
+    {
+        match self.inner.read(stream, buffer).await {
+            Some(Ok(read_result)) => Ok(Some(read_result)),
+            Some(Err(error)) => Err!(XRPLWebsocketException::from(error)),
+            None => Ok(None),
+        }
+    }
+}

--- a/src/asynch/clients/exceptions.rs
+++ b/src/asynch/clients/exceptions.rs
@@ -1,0 +1,40 @@
+use core::fmt::Debug;
+use core::str::Utf8Error;
+use embedded_websocket::framer_async::FramerError;
+use thiserror_no_std::Error;
+
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum XRPLWebsocketException<E: Debug> {
+    // FramerError
+    #[error("I/O error: {0:?}")]
+    Io(E),
+    #[error("Frame too large (size: {0:?})")]
+    FrameTooLarge(usize),
+    #[error("Failed to interpret u8 to string (error: {0:?})")]
+    Utf8(Utf8Error),
+    #[error("Invalid HTTP header")]
+    HttpHeader,
+    #[error("Websocket error: {0:?}")]
+    WebSocket(embedded_websocket::Error),
+    #[error("Disconnected")]
+    Disconnected,
+    #[error("Read buffer is too small (size: {0:?})")]
+    RxBufferTooSmall(usize),
+}
+
+impl<E: Debug> From<FramerError<E>> for XRPLWebsocketException<E> {
+    fn from(value: FramerError<E>) -> Self {
+        match value {
+            FramerError::Io(e) => XRPLWebsocketException::Io(e),
+            FramerError::FrameTooLarge(e) => XRPLWebsocketException::FrameTooLarge(e),
+            FramerError::Utf8(e) => XRPLWebsocketException::Utf8(e),
+            FramerError::HttpHeader(_) => XRPLWebsocketException::HttpHeader,
+            FramerError::WebSocket(e) => XRPLWebsocketException::WebSocket(e),
+            FramerError::Disconnected => XRPLWebsocketException::Disconnected,
+            FramerError::RxBufferTooSmall(e) => XRPLWebsocketException::RxBufferTooSmall(e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E: Debug> alloc::error::Error for XRPLWebsocketException<E> {}

--- a/src/asynch/clients/mod.rs
+++ b/src/asynch/clients/mod.rs
@@ -1,0 +1,6 @@
+mod async_json_rpc_client;
+mod async_websocket_client;
+mod exceptions;
+
+pub use async_json_rpc_client::*;
+pub use async_websocket_client::*;

--- a/src/asynch/mod.rs
+++ b/src/asynch/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "net")]
+pub mod clients;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std as alloc;
 
+pub mod asynch;
 pub mod constants;
 #[cfg(feature = "core")]
 pub mod core;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,3 +1,0 @@
-/// Setup common testing prerequisites here such as connecting a client
-/// to a server or creating required files/directories if needed.
-pub fn setup() {}

--- a/tests/common/codec.rs
+++ b/tests/common/codec.rs
@@ -1,0 +1,35 @@
+use bytes::{BufMut, BytesMut};
+use std::io;
+use tokio_util::codec::{Decoder, Encoder};
+
+pub struct Codec {}
+
+impl Codec {
+    pub fn new() -> Self {
+        Codec {}
+    }
+}
+
+impl Decoder for Codec {
+    type Item = BytesMut;
+    type Error = io::Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<BytesMut>, io::Error> {
+        if !buf.is_empty() {
+            let len = buf.len();
+            Ok(Some(buf.split_to(len)))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl Encoder<&[u8]> for Codec {
+    type Error = io::Error;
+
+    fn encode(&mut self, data: &[u8], buf: &mut BytesMut) -> Result<(), io::Error> {
+        buf.reserve(data.len());
+        buf.put(data);
+        Ok(())
+    }
+}

--- a/tests/common/constants.rs
+++ b/tests/common/constants.rs
@@ -1,0 +1,2 @@
+pub const ECHO_WS_SERVER: &'static str = "ws://ws.vi-server.org/mirror/";
+pub const ECHO_WSS_SERVER: &'static str = "wss://ws.vi-server.org/mirror/";

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,43 @@
+pub mod codec;
+#[cfg(feature = "tungstenite")]
+use xrpl::asynch::clients::AsyncWebsocketClientTungstenite;
+use xrpl::asynch::clients::{
+    AsyncWebsocketClientEmbeddedWebsocket, EmbeddedWebsocketOptions, WebsocketOpen,
+};
+
+use tokio::net::TcpStream;
+use tokio_util::codec::Framed;
+
+mod constants;
+pub use constants::*;
+
+#[cfg(feature = "tungstenite")]
+pub async fn connect_to_wss_tungstinite_echo() -> AsyncWebsocketClientTungstenite<WebsocketOpen> {
+    let websocket = AsyncWebsocketClientTungstenite::open(ECHO_WSS_SERVER.parse().unwrap())
+        .await
+        .unwrap();
+    assert!(websocket.is_open());
+
+    websocket
+}
+
+pub async fn connect_to_ws_embedded_websocket_tokio_echo(
+    stream: &mut Framed<TcpStream, codec::Codec>,
+    buffer: &mut [u8],
+) -> AsyncWebsocketClientEmbeddedWebsocket<rand::rngs::ThreadRng, WebsocketOpen> {
+    let rng = rand::thread_rng();
+    let websocket_options = EmbeddedWebsocketOptions {
+        path: "/mirror",
+        host: "ws.vi-server.org",
+        origin: "http://ws.vi-server.org:80",
+        sub_protocols: None,
+        additional_headers: None,
+    };
+
+    let websocket =
+        AsyncWebsocketClientEmbeddedWebsocket::open(stream, buffer, rng, &websocket_options)
+            .await
+            .unwrap();
+
+    websocket
+}

--- a/tests/integration/clients/mod.rs
+++ b/tests/integration/clients/mod.rs
@@ -1,0 +1,81 @@
+#[cfg(feature = "tungstenite")]
+use super::common::connect_to_wss_tungstinite_echo;
+use super::common::{codec::Codec, connect_to_ws_embedded_websocket_tokio_echo};
+#[cfg(feature = "tungstenite")]
+use futures::{SinkExt, TryStreamExt};
+use tokio_util::codec::Framed;
+use xrpl::asynch::clients::EmbeddedWebsocketReadMessageType;
+
+#[cfg(feature = "tungstenite")]
+use xrpl::asynch::clients::TungsteniteMessage;
+use xrpl::models::requests::AccountInfo;
+
+#[cfg(feature = "tungstenite")]
+#[tokio::test]
+async fn test_websocket_tungstenite_echo() {
+    let mut websocket = connect_to_wss_tungstinite_echo().await;
+    let account_info = AccountInfo::new(
+        "rJumr5e1HwiuV543H7bqixhtFreChWTaHH",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    websocket.send(&account_info).await.unwrap();
+
+    while let Ok(Some(TungsteniteMessage::Text(response))) = websocket.try_next().await {
+        let account_info_echo: AccountInfo = serde_json::from_str(response.as_str()).unwrap();
+        println!("account_info_echo: {:?}", account_info_echo);
+        assert_eq!(account_info, account_info_echo);
+
+        break;
+    }
+}
+
+#[tokio::test]
+async fn test_embedded_websocket_echo() {
+    let tcp_stream = tokio::net::TcpStream::connect("ws.vi-server.org:80")
+        .await
+        .unwrap();
+    let mut framed = Framed::new(tcp_stream, Codec::new());
+    let mut buffer = [0u8; 4096];
+    let mut websocket = connect_to_ws_embedded_websocket_tokio_echo(&mut framed, &mut buffer).await;
+    let account_info = AccountInfo::new(
+        "rJumr5e1HwiuV543H7bqixhtFreChWTaHH",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    websocket
+        .send(&mut framed, &mut buffer, false, &account_info)
+        .await
+        .unwrap();
+
+    let mut ping_counter = 0;
+    loop {
+        let message = websocket
+            .try_next(&mut framed, &mut buffer)
+            .await
+            .unwrap()
+            .unwrap();
+        match message {
+            EmbeddedWebsocketReadMessageType::Binary(msg) => {
+                assert_eq!(serde_json::to_vec(&account_info).unwrap().as_slice(), msg);
+                break;
+            }
+            EmbeddedWebsocketReadMessageType::Ping(_) => {
+                ping_counter += 1;
+                if ping_counter > 1 {
+                    panic!("Expected only one ping");
+                }
+            }
+            _ => panic!("Expected binary message"),
+        }
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,0 +1,3 @@
+use super::common;
+
+mod clients;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,4 @@
+#![allow(dead_code)] // Remove eventually
+mod common;
+
+mod integration;


### PR DESCRIPTION
## High Level Overview of Change

This PR is a replacement of #67 to fix the incorrect base branch of #67 . The changes are basically the same.

Adds an `AsyncWebsocketClient` to establish a websocket connection to a XRPL node.
Features:
`"net"` and `"std"`: To establish a websocket connection the crate [embedded-websocket](https://github.com/ninjasource/embedded-websocket) is used. It can be used together with the [`tokio::net::TcpStream`](https://github.com/tokio-rs/tokio/blob/master/tokio/src/net/tcp/stream.rs)
`"net"`: To establish a websocket connection the crate [embedded-websocket](https://github.com/ninjasource/embedded-websocket) is used.
`"net"` and `"tungstenite"`: To establish a websocket connection the crate [tokio-tungstenite](https://github.com/snapview/tokio-tungstenite) is used.

The PR also updates some dependencies.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

## TODO:
- [ ] Handle unwraps
