### PR TITLE
Revise models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,13 @@ serde_json = { version = "1.0.68", default-features = false, features = [
 serde_with = "3.2.0"
 serde_repr = "0.1"
 zeroize = "1.5.7"
-hashbrown = { version = "0.14.0", default-features = false, features = ["serde"] }
+hashbrown = { version = "0.14.0", default-features = false, features = [
+    "serde",
+] }
 fnv = { version = "1.0.7", default-features = false }
 derive-new = { version = "0.5.9", default-features = false }
 thiserror-no-std = "2.0.2"
-anyhow = { version ="1.0.69", default-features = false }
+anyhow = { version = "1.0.69", default-features = false }
 tokio = { version = "1.28.0", default-features = false, optional = true }
 url = { version = "2.2.2", default-features = false, optional = true }
 futures = { version = "0.3.28", default-features = false, optional = true }
@@ -86,7 +88,15 @@ name = "benchmarks"
 harness = false
 
 [features]
-default = ["std", "core", "models", "utils", "net", "tungstenite", "embedded-websocket"]
+default = [
+    "std",
+    "core",
+    "models",
+    "utils",
+    "net",
+    "tungstenite",
+    "embedded-websocket",
+]
 models = ["core", "transactions", "requests", "ledger"]
 transactions = ["core", "amounts", "currencies"]
 requests = ["core", "amounts", "currencies"]

--- a/src/models/ledger/objects/amendments.rs
+++ b/src/models/ledger/objects/amendments.rs
@@ -1,7 +1,7 @@
 use crate::models::ledger::LedgerEntryType;
 use crate::models::Model;
-use alloc::{borrow::Cow, string::String};
 use alloc::vec::Vec;
+use alloc::{borrow::Cow, string::String};
 use derive_new::new;
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 
@@ -79,8 +79,8 @@ impl<'a> Amendments<'a> {
 #[cfg(test)]
 mod test_serde {
     use crate::models::ledger::{Amendments, Majority};
-    use alloc::string::ToString;
     use alloc::borrow::Cow;
+    use alloc::string::ToString;
     use alloc::vec;
 
     #[test]
@@ -94,7 +94,8 @@ mod test_serde {
                 Cow::from("740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11"),
             ]),
             Some(vec![Majority {
-                amendment: "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146".to_string(),
+                amendment: "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146"
+                    .to_string(),
                 close_time: 535589001,
             }]),
         );

--- a/src/models/ledger/objects/amendments.rs
+++ b/src/models/ledger/objects/amendments.rs
@@ -1,6 +1,6 @@
 use crate::models::ledger::LedgerEntryType;
 use crate::models::Model;
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, string::String};
 use alloc::vec::Vec;
 use derive_new::new;
 use serde::{ser::SerializeMap, Deserialize, Serialize};
@@ -11,9 +11,9 @@ use serde_with::skip_serializing_none;
 serde_with_tag! {
     /// `<https://xrpl.org/amendments-object.html#amendments-fields>`
     #[derive(Debug, PartialEq, Eq, Clone, new, Default)]
-    pub struct Majority<'a> {
+    pub struct Majority {
         /// The Amendment ID of the pending amendment.
-        pub amendment: Cow<'a, str>,
+        pub amendment: String,
         /// The `close_time` field of the ledger version where this amendment most recently gained a
         /// majority.
         pub close_time: u32,
@@ -43,8 +43,7 @@ pub struct Amendments<'a> {
     pub amendments: Option<Vec<Cow<'a, str>>>,
     /// Array of objects describing the status of amendments that have majority support but are not
     /// yet enabled. If omitted, there are no pending amendments with majority support.
-    #[serde(borrow = "'a")]
-    pub majorities: Option<Vec<Majority<'a>>>,
+    pub majorities: Option<Vec<Majority>>,
 }
 
 impl<'a> Model for Amendments<'a> {}
@@ -65,7 +64,7 @@ impl<'a> Amendments<'a> {
     pub fn new(
         index: Cow<'a, str>,
         amendments: Option<Vec<Cow<'a, str>>>,
-        majorities: Option<Vec<Majority<'a>>>,
+        majorities: Option<Vec<Majority>>,
     ) -> Self {
         Self {
             ledger_entry_type: LedgerEntryType::Amendments,
@@ -80,6 +79,7 @@ impl<'a> Amendments<'a> {
 #[cfg(test)]
 mod test_serde {
     use crate::models::ledger::{Amendments, Majority};
+    use alloc::string::ToString;
     use alloc::borrow::Cow;
     use alloc::vec;
 
@@ -94,9 +94,7 @@ mod test_serde {
                 Cow::from("740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11"),
             ]),
             Some(vec![Majority {
-                amendment: Cow::from(
-                    "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146",
-                ),
+                amendment: "1562511F573A19AE9BD103B5D6B9E01B3B46805AEC5D3C4805C902B514399146".to_string(),
                 close_time: 535589001,
             }]),
         );

--- a/src/models/ledger/objects/amm.rs
+++ b/src/models/ledger/objects/amm.rs
@@ -134,8 +134,8 @@ mod test_serde {
     use crate::models::amount::{Amount, IssuedCurrencyAmount};
     use crate::models::currency::{Currency, IssuedCurrency, XRP};
     use crate::models::ledger::amm::{AuctionSlot, AuthAccount, VoteEntry, AMM};
-    use alloc::string::ToString;
     use alloc::borrow::Cow;
+    use alloc::string::ToString;
     use alloc::vec;
 
     #[test]

--- a/src/models/ledger/objects/amm.rs
+++ b/src/models/ledger/objects/amm.rs
@@ -1,6 +1,7 @@
 use crate::models::ledger::LedgerEntryType;
 use crate::models::{amount::Amount, Currency, Model};
 use alloc::borrow::Cow;
+use alloc::string::String;
 use alloc::vec::Vec;
 use derive_new::new;
 use serde::{ser::SerializeMap, Deserialize, Serialize};
@@ -10,8 +11,8 @@ use serde_with::skip_serializing_none;
 
 serde_with_tag! {
     #[derive(Debug, PartialEq, Eq, Clone, new, Default)]
-    pub struct AuthAccount<'a> {
-        pub account: Cow<'a, str>,
+    pub struct AuthAccount {
+        pub account: String,
     }
 }
 
@@ -31,14 +32,13 @@ pub struct AuctionSlot<'a> {
     pub price: Amount<'a>,
     /// A list of at most 4 additional accounts that are authorized to trade at the discounted fee
     /// for this AMM instance.
-    #[serde(borrow = "'a")]
-    pub auth_accounts: Option<Vec<AuthAccount<'a>>>,
+    pub auth_accounts: Option<Vec<AuthAccount>>,
 }
 
 serde_with_tag! {
     #[derive(Debug, PartialEq, Eq, Clone, new, Default)]
-    pub struct VoteEntry<'a> {
-        pub account: Cow<'a, str>,
+    pub struct VoteEntry {
+        pub account: String,
         pub trading_fee: u16,
         pub vote_weight: u32,
     }
@@ -81,7 +81,7 @@ pub struct AMM<'a> {
     #[serde(borrow = "'a")]
     pub auction_slot: Option<AuctionSlot<'a>>,
     /// A list of vote objects, representing votes on the pool's trading fee.
-    pub vote_slots: Option<Vec<VoteEntry<'a>>>,
+    pub vote_slots: Option<Vec<VoteEntry>>,
 }
 
 impl<'a> Default for AMM<'a> {
@@ -112,7 +112,7 @@ impl<'a> AMM<'a> {
         lptoken_balance: Amount<'a>,
         trading_fee: u16,
         auction_slot: Option<AuctionSlot<'a>>,
-        vote_slots: Option<Vec<VoteEntry<'a>>>,
+        vote_slots: Option<Vec<VoteEntry>>,
     ) -> Self {
         Self {
             ledger_entry_type: LedgerEntryType::AMM,
@@ -134,6 +134,7 @@ mod test_serde {
     use crate::models::amount::{Amount, IssuedCurrencyAmount};
     use crate::models::currency::{Currency, IssuedCurrency, XRP};
     use crate::models::ledger::amm::{AuctionSlot, AuthAccount, VoteEntry, AMM};
+    use alloc::string::ToString;
     use alloc::borrow::Cow;
     use alloc::vec;
 
@@ -163,12 +164,12 @@ mod test_serde {
                     "0.8696263565463045".into(),
                 )),
                 Some(vec![
-                    AuthAccount::new(Cow::from("rMKXGCbJ5d8LbrqthdG46q3f969MVK2Qeg")),
-                    AuthAccount::new(Cow::from("rBepJuTLFJt3WmtLXYAxSjtBWAeQxVbncv")),
+                    AuthAccount::new("rMKXGCbJ5d8LbrqthdG46q3f969MVK2Qeg".to_string()),
+                    AuthAccount::new("rBepJuTLFJt3WmtLXYAxSjtBWAeQxVbncv".to_string()),
                 ]),
             )),
             Some(vec![VoteEntry::new(
-                Cow::from("rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"),
+                "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm".to_string(),
                 600,
                 100000,
             )]),

--- a/src/models/ledger/objects/negative_unl.rs
+++ b/src/models/ledger/objects/negative_unl.rs
@@ -1,7 +1,7 @@
 use crate::models::ledger::LedgerEntryType;
 use crate::models::Model;
 use alloc::borrow::Cow;
-
+use alloc::string::String;
 use alloc::vec::Vec;
 use derive_new::new;
 use serde::{ser::SerializeMap, Deserialize, Serialize};
@@ -12,11 +12,11 @@ use serde_with::skip_serializing_none;
 serde_with_tag! {
     /// Each `DisabledValidator` object represents one disabled validator.
     #[derive(Debug, PartialEq, Eq, Clone, new, Default)]
-    pub struct DisabledValidator<'a> {
+    pub struct DisabledValidator {
         /// The ledger index when the validator was added to the Negative UNL.
         pub first_ledger_sequence: u32,
         /// The master public key of the validator, in hexadecimal.
-        pub public_key: Cow<'a, str>,
+        pub public_key: String,
     }
 }
 
@@ -40,8 +40,7 @@ pub struct NegativeUNL<'a> {
     pub index: Cow<'a, str>,
     /// A list of `DisabledValidator` objects (see below), each representing a trusted validator
     /// that is currently disabled.
-    #[serde(borrow = "'a")]
-    pub disabled_validators: Option<Vec<DisabledValidator<'a>>>,
+    pub disabled_validators: Option<Vec<DisabledValidator>>,
     /// The public key of a trusted validator that is scheduled to be disabled in the
     /// next flag ledger.
     pub validator_to_disable: Option<Cow<'a, str>>,
@@ -68,7 +67,7 @@ impl<'a> Model for NegativeUNL<'a> {}
 impl<'a> NegativeUNL<'a> {
     pub fn new(
         index: Cow<'a, str>,
-        disabled_validators: Option<Vec<DisabledValidator<'a>>>,
+        disabled_validators: Option<Vec<DisabledValidator>>,
         validator_to_disable: Option<Cow<'a, str>>,
         validator_to_re_enable: Option<Cow<'a, str>>,
     ) -> Self {
@@ -86,6 +85,7 @@ impl<'a> NegativeUNL<'a> {
 #[cfg(test)]
 mod test_serde {
     use super::*;
+    use alloc::string::ToString;
     use alloc::vec;
 
     #[test]
@@ -94,7 +94,7 @@ mod test_serde {
             Cow::from("2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244"),
             Some(vec![DisabledValidator::new(
                 1609728,
-                Cow::from("ED6629D456285AE3613B285F65BBFF168D695BA3921F309949AFCD2CA7AFEC16FE"),
+                "ED6629D456285AE3613B285F65BBFF168D695BA3921F309949AFCD2CA7AFEC16FE".to_string(),
             )]),
             None,
             None,

--- a/src/models/ledger/objects/signer_list.rs
+++ b/src/models/ledger/objects/signer_list.rs
@@ -2,7 +2,7 @@ use crate::_serde::lgr_obj_flags;
 use crate::models::ledger::LedgerEntryType;
 use crate::models::Model;
 use alloc::borrow::Cow;
-
+use alloc::string::String;
 use alloc::vec::Vec;
 use derive_new::new;
 use serde::{ser::SerializeMap, Deserialize, Serialize};
@@ -26,14 +26,14 @@ serde_with_tag! {
     ///
     /// `<https://xrpl.org/signerlist.html#signer-entry-object>`
     #[derive(Debug, PartialEq, Eq, Clone, new, Default)]
-    pub struct SignerEntry<'a>{
+    pub struct SignerEntry {
         /// An XRP Ledger address whose signature contributes to the multi-signature.
-        pub account: Cow<'a, str>,
+        pub account: String,
         /// The weight of a signature from this signer.
         pub signer_weight: u16,
         /// Arbitrary hexadecimal data. This can be used to identify the signer or for
         /// other, related purposes.
-        pub wallet_locator: Option<Cow<'a, str>>,
+        pub wallet_locator: Option<String>,
     }
 }
 
@@ -66,8 +66,7 @@ pub struct SignerList<'a> {
     pub previous_txn_lgr_seq: u32,
     /// An array of Signer Entry objects representing the parties who are part of this
     /// signer list.
-    #[serde(borrow = "'a")]
-    pub signer_entries: Vec<SignerEntry<'a>>,
+    pub signer_entries: Vec<SignerEntry>,
     /// An ID for this signer list. Currently always set to 0.
     #[serde(rename = "SignerListID")]
     pub signer_list_id: u32,
@@ -102,7 +101,7 @@ impl<'a> SignerList<'a> {
         owner_node: Cow<'a, str>,
         previous_txn_id: Cow<'a, str>,
         previous_txn_lgr_seq: u32,
-        signer_entries: Vec<SignerEntry<'a>>,
+        signer_entries: Vec<SignerEntry>,
         signer_list_id: u32,
         signer_quorum: u32,
     ) -> Self {
@@ -123,6 +122,7 @@ impl<'a> SignerList<'a> {
 #[cfg(test)]
 mod test_serde {
     use super::*;
+    use alloc::string::ToString;
     use alloc::vec;
 
     #[test]
@@ -134,9 +134,9 @@ mod test_serde {
             Cow::from("5904C0DC72C58A83AEFED2FFC5386356AA83FCA6A88C89D00646E51E687CDBE4"),
             16061435,
             vec![
-                SignerEntry::new(Cow::from("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"), 2, None),
-                SignerEntry::new(Cow::from("raKEEVSGnKSD9Zyvxu4z6Pqpm4ABH8FS6n"), 1, None),
-                SignerEntry::new(Cow::from("rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v"), 1, None),
+                SignerEntry::new("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW".to_string(), 2, None),
+                SignerEntry::new("raKEEVSGnKSD9Zyvxu4z6Pqpm4ABH8FS6n".to_string(), 1, None),
+                SignerEntry::new("rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v".to_string(), 1, None),
             ],
             0,
             3,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -28,6 +28,7 @@ use derive_new::new;
 pub use model::Model;
 
 use crate::models::currency::{Currency, XRP};
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 
@@ -52,11 +53,11 @@ pub enum AccountObjectType {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, new)]
 #[serde(rename_all = "PascalCase")]
 pub struct PathStep<'a> {
-    account: Option<&'a str>,
-    currency: Option<&'a str>,
-    issuer: Option<&'a str>,
+    account: Option<Cow<'a, str>>,
+    currency: Option<Cow<'a, str>>,
+    issuer: Option<Cow<'a, str>>,
     r#type: Option<u8>,
-    type_hex: Option<&'a str>,
+    type_hex: Option<Cow<'a, str>>,
 }
 
 /// Returns a Currency as XRP for the currency, without a value.

--- a/src/models/requests/account_channels.rs
+++ b/src/models/requests/account_channels.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -35,21 +36,21 @@ pub struct AccountChannels<'a> {
     /// The unique identifier of an account, typically the
     /// account's Address. The request returns channels where
     /// this account is the channel's owner/source.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// Limit the number of transactions to retrieve. Cannot
     /// be less than 10 or more than 400. The default is 200.
     pub limit: Option<u16>,
     /// The unique identifier of an account, typically the
     /// account's Address. If provided, filter results to
     /// payment channels whose destination is this account.
-    pub destination_account: Option<&'a str>,
+    pub destination_account: Option<Cow<'a, str>>,
     /// Value from a previous paginated response.
     /// Resume retrieving data where that response left off.
     pub marker: Option<u32>,
@@ -61,7 +62,7 @@ pub struct AccountChannels<'a> {
 impl<'a> Default for AccountChannels<'a> {
     fn default() -> Self {
         AccountChannels {
-            account: "",
+            account: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -77,12 +78,12 @@ impl<'a> Model for AccountChannels<'a> {}
 
 impl<'a> AccountChannels<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         limit: Option<u16>,
-        destination_account: Option<&'a str>,
+        destination_account: Option<Cow<'a, str>>,
         marker: Option<u32>,
     ) -> Self {
         Self {

--- a/src/models/requests/account_currencies.rs
+++ b/src/models/requests/account_currencies.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -15,14 +16,14 @@ use crate::models::{default_false, requests::RequestMethod, Model};
 pub struct AccountCurrencies<'a> {
     /// A unique identifier for the account, most commonly
     /// the account's Address.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// If true, then the account field only accepts a public
     /// key or XRP Ledger address. Otherwise, account can be
     /// a secret or passphrase (not recommended).
@@ -37,7 +38,7 @@ pub struct AccountCurrencies<'a> {
 impl<'a> Default for AccountCurrencies<'a> {
     fn default() -> Self {
         AccountCurrencies {
-            account: "",
+            account: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -51,10 +52,10 @@ impl<'a> Model for AccountCurrencies<'a> {}
 
 impl<'a> AccountCurrencies<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         strict: Option<bool>,
     ) -> Self {
         Self {

--- a/src/models/requests/account_info.rs
+++ b/src/models/requests/account_info.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -14,14 +15,14 @@ use crate::models::{requests::RequestMethod, Model};
 pub struct AccountInfo<'a> {
     /// A unique identifier for the account, most commonly the
     /// account's Address.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// If true, then the account field only accepts a public
     /// key or XRP Ledger address. Otherwise, account can be
     /// a secret or passphrase (not recommended).
@@ -44,7 +45,7 @@ pub struct AccountInfo<'a> {
 impl<'a> Default for AccountInfo<'a> {
     fn default() -> Self {
         AccountInfo {
-            account: "",
+            account: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -60,10 +61,10 @@ impl<'a> Model for AccountInfo<'a> {}
 
 impl<'a> AccountInfo<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         strict: Option<bool>,
         queue: Option<bool>,
         signer_lists: Option<bool>,

--- a/src/models/requests/account_lines.rs
+++ b/src/models/requests/account_lines.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -15,21 +16,21 @@ use crate::models::{requests::RequestMethod, Model};
 pub struct AccountLines<'a> {
     /// A unique identifier for the account, most commonly the
     /// account's Address.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// Limit the number of trust lines to retrieve. The server
     /// is not required to honor this value. Must be within the
     /// inclusive range 10 to 400.
     pub limit: Option<u16>,
     /// The Address of a second account. If provided, show only
     /// lines of trust connecting the two accounts.
-    pub peer: Option<&'a str>,
+    pub peer: Option<Cow<'a, str>>,
     /// Value from a previous paginated response. Resume retrieving
     /// data where that response left off.
     pub marker: Option<u32>,
@@ -41,7 +42,7 @@ pub struct AccountLines<'a> {
 impl<'a> Default for AccountLines<'a> {
     fn default() -> Self {
         AccountLines {
-            account: "",
+            account: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -57,12 +58,12 @@ impl<'a> Model for AccountLines<'a> {}
 
 impl<'a> AccountLines<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         limit: Option<u16>,
-        peer: Option<&'a str>,
+        peer: Option<Cow<'a, str>>,
         marker: Option<u32>,
     ) -> Self {
         Self {

--- a/src/models/requests/account_nfts.rs
+++ b/src/models/requests/account_nfts.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -11,9 +12,9 @@ pub struct AccountNfts<'a> {
     /// The unique identifier of an account, typically the
     /// account's Address. The request returns a list of
     /// NFTs owned by this account.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// Limit the number of token pages to retrieve. Each page
     /// can contain up to 32 NFTs. The limit value cannot be
     /// lower than 20 or more than 400. The default is 100.
@@ -29,7 +30,7 @@ pub struct AccountNfts<'a> {
 impl<'a> Default for AccountNfts<'a> {
     fn default() -> Self {
         AccountNfts {
-            account: "",
+            account: "".into(),
             id: None,
             limit: None,
             marker: None,
@@ -42,8 +43,8 @@ impl<'a> Model for AccountNfts<'a> {}
 
 impl<'a> AccountNfts<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
         limit: Option<u32>,
         marker: Option<u32>,
     ) -> Self {

--- a/src/models/requests/account_objects.rs
+++ b/src/models/requests/account_objects.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use strum_macros::Display;
@@ -32,14 +33,14 @@ pub enum AccountObjectType {
 pub struct AccountObjects<'a> {
     /// A unique identifier for the account, most commonly the
     /// account's address.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// If included, filter results to include only this type
     /// of ledger object. The valid types are: check, deposit_preauth,
     /// escrow, offer, payment_channel, signer_list, ticket,
@@ -63,7 +64,7 @@ pub struct AccountObjects<'a> {
 impl<'a> Default for AccountObjects<'a> {
     fn default() -> Self {
         AccountObjects {
-            account: "",
+            account: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -80,10 +81,10 @@ impl<'a> Model for AccountObjects<'a> {}
 
 impl<'a> AccountObjects<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         r#type: Option<AccountObjectType>,
         deletion_blockers_only: Option<bool>,
         limit: Option<u16>,

--- a/src/models/requests/account_offers.rs
+++ b/src/models/requests/account_offers.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -13,14 +14,14 @@ use crate::models::{requests::RequestMethod, Model};
 pub struct AccountOffers<'a> {
     /// A unique identifier for the account, most commonly the
     /// account's Address.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string identifying the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or "current",
     /// "closed", or "validated" to select a ledger dynamically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// Limit the number of transactions to retrieve. The server is
     /// not required to honor this value. Must be within the inclusive
     /// range 10 to 400.
@@ -40,7 +41,7 @@ pub struct AccountOffers<'a> {
 impl<'a> Default for AccountOffers<'a> {
     fn default() -> Self {
         AccountOffers {
-            account: "",
+            account: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -56,10 +57,10 @@ impl<'a> Model for AccountOffers<'a> {}
 
 impl<'a> AccountOffers<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         limit: Option<u16>,
         strict: Option<bool>,
         marker: Option<u32>,

--- a/src/models/requests/account_tx.rs
+++ b/src/models/requests/account_tx.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -13,13 +14,13 @@ use crate::models::{requests::RequestMethod, Model};
 pub struct AccountTx<'a> {
     /// A unique identifier for the account, most commonly the
     /// account's address.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// Use to look for transactions from a single ledger only.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// Use to look for transactions from a single ledger only.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// Defaults to false. If set to true, returns transactions
     /// as hex strings instead of JSON.
     pub binary: Option<bool>,
@@ -53,7 +54,7 @@ pub struct AccountTx<'a> {
 impl<'a> Default for AccountTx<'a> {
     fn default() -> Self {
         AccountTx {
-            account: "",
+            account: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -72,10 +73,10 @@ impl<'a> Model for AccountTx<'a> {}
 
 impl<'a> AccountTx<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         binary: Option<bool>,
         forward: Option<bool>,
         ledger_index_min: Option<u32>,

--- a/src/models/requests/book_offers.rs
+++ b/src/models/requests/book_offers.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -22,12 +23,12 @@ pub struct BookOffers<'a> {
     /// like currency amounts.
     pub taker_pays: Currency<'a>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// If provided, the server does not provide more than
     /// this many offers in the results. The total number of
     /// results returned may be fewer than the limit,
@@ -37,7 +38,7 @@ pub struct BookOffers<'a> {
     /// Unfunded offers placed by this account are always
     /// included in the response. (You can use this to look
     /// up your own orders to cancel them.)
-    pub taker: Option<&'a str>,
+    pub taker: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::book_offers")]
     pub command: RequestMethod,
@@ -64,11 +65,11 @@ impl<'a> BookOffers<'a> {
     pub fn new(
         taker_gets: Currency<'a>,
         taker_pays: Currency<'a>,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         limit: Option<u16>,
-        taker: Option<&'a str>,
+        taker: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             taker_gets,

--- a/src/models/requests/channel_authorize.rs
+++ b/src/models/requests/channel_authorize.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -31,37 +32,37 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct ChannelAuthorize<'a> {
     /// The unique ID of the payment channel to use.
-    pub channel_id: &'a str,
+    pub channel_id: Cow<'a, str>,
     /// Cumulative amount of XRP, in drops, to authorize.
     /// If the destination has already received a lesser amount
     /// of XRP from this channel, the signature created by this
     /// method can be redeemed for the difference.
-    pub amount: &'a str,
+    pub amount: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The secret key to use to sign the claim. This must be
     /// the same key pair as the public key specified in the
     /// channel. Cannot be used with seed, seed_hex, or passphrase.
-    pub secret: Option<&'a str>,
+    pub secret: Option<Cow<'a, str>>,
     /// The secret seed to use to sign the claim. This must be
     /// the same key pair as the public key specified in the channel.
     /// Must be in the XRP Ledger's base58 format. If provided,
     /// you must also specify the key_type. Cannot be used with
     /// secret, seed_hex, or passphrase.
-    pub seed: Option<&'a str>,
+    pub seed: Option<Cow<'a, str>>,
     /// The secret seed to use to sign the claim. This must be the
     /// same key pair as the public key specified in the channel.
     /// Must be in hexadecimal format. If provided, you must also
     /// specify the key_type. Cannot be used with secret, seed,
     /// or passphrase.
-    pub seed_hex: Option<&'a str>,
+    pub seed_hex: Option<Cow<'a, str>>,
     /// A string passphrase to use to sign the claim. This must be
     /// the same key pair as the public key specified in the channel.
     /// The key derived from this passphrase must match the public
     /// key specified in the channel. If provided, you must also
     /// specify the key_type. Cannot be used with secret, seed,
     /// or seed_hex.
-    pub passphrase: Option<&'a str>,
+    pub passphrase: Option<Cow<'a, str>>,
     /// The signing algorithm of the cryptographic key pair provided.
     /// Valid types are secp256k1 or ed25519. The default is secp256k1.
     pub key_type: Option<CryptoAlgorithm>,
@@ -73,8 +74,8 @@ pub struct ChannelAuthorize<'a> {
 impl<'a> Default for ChannelAuthorize<'a> {
     fn default() -> Self {
         ChannelAuthorize {
-            channel_id: "",
-            amount: "",
+            channel_id: "".into(),
+            amount: "".into(),
             id: None,
             secret: None,
             seed: None,
@@ -98,18 +99,18 @@ impl<'a> Model for ChannelAuthorize<'a> {
 impl<'a> ChannelAuthorizeError for ChannelAuthorize<'a> {
     fn _get_field_error(&self) -> Result<(), XRPLChannelAuthorizeException> {
         let mut signing_methods = Vec::new();
-        for method in [self.secret, self.seed, self.seed_hex, self.passphrase] {
+        for method in [self.secret.clone(), self.seed.clone(), self.seed_hex.clone(), self.passphrase.clone()] {
             if method.is_some() {
                 signing_methods.push(method)
             }
         }
         if signing_methods.len() != 1 {
             Err(XRPLChannelAuthorizeException::DefineExactlyOneOf {
-                field1: "secret",
-                field2: "seed",
-                field3: "seed_hex",
-                field4: "passphrase",
-                resource: "",
+                field1: "secret".into(),
+                field2: "seed".into(),
+                field3: "seed_hex".into(),
+                field4: "passphrase".into(),
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -119,13 +120,13 @@ impl<'a> ChannelAuthorizeError for ChannelAuthorize<'a> {
 
 impl<'a> ChannelAuthorize<'a> {
     pub fn new(
-        channel_id: &'a str,
-        amount: &'a str,
-        id: Option<&'a str>,
-        secret: Option<&'a str>,
-        seed: Option<&'a str>,
-        seed_hex: Option<&'a str>,
-        passphrase: Option<&'a str>,
+        channel_id: Cow<'a, str>,
+        amount: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        secret: Option<Cow<'a, str>>,
+        seed: Option<Cow<'a, str>>,
+        seed_hex: Option<Cow<'a, str>>,
+        passphrase: Option<Cow<'a, str>>,
         key_type: Option<CryptoAlgorithm>,
     ) -> Self {
         Self {
@@ -158,12 +159,12 @@ mod test_channel_authorize_errors {
     fn test_fields_error() {
         let channel_authorize = ChannelAuthorize {
             command: RequestMethod::ChannelAuthorize,
-            channel_id: "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3",
-            amount: "1000000",
+            channel_id: "5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3".into(),
+            amount: "1000000".into(),
             id: None,
             secret: None,
-            seed: Some(""),
-            seed_hex: Some(""),
+            seed: Some("".into()),
+            seed_hex: Some("".into()),
             passphrase: None,
             key_type: Some(CryptoAlgorithm::SECP256K1),
         };

--- a/src/models/requests/channel_authorize.rs
+++ b/src/models/requests/channel_authorize.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -99,7 +99,12 @@ impl<'a> Model for ChannelAuthorize<'a> {
 impl<'a> ChannelAuthorizeError for ChannelAuthorize<'a> {
     fn _get_field_error(&self) -> Result<(), XRPLChannelAuthorizeException> {
         let mut signing_methods = Vec::new();
-        for method in [self.secret.clone(), self.seed.clone(), self.seed_hex.clone(), self.passphrase.clone()] {
+        for method in [
+            self.secret.clone(),
+            self.seed.clone(),
+            self.seed_hex.clone(),
+            self.passphrase.clone(),
+        ] {
             if method.is_some() {
                 signing_methods.push(method)
             }

--- a/src/models/requests/channel_verify.rs
+++ b/src/models/requests/channel_verify.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -11,17 +12,17 @@ use crate::models::{requests::RequestMethod, Model};
 pub struct ChannelVerify<'a> {
     /// The Channel ID of the channel that provides the XRP.
     /// This is a 64-character hexadecimal string.
-    pub channel_id: &'a str,
+    pub channel_id: Cow<'a, str>,
     /// The amount of XRP, in drops, the provided signature authorizes.
-    pub amount: &'a str,
+    pub amount: Cow<'a, str>,
     /// The public key of the channel and the key pair that was used to
     /// create the signature, in hexadecimal or the XRP Ledger's
     /// base58 format.
-    pub public_key: &'a str,
+    pub public_key: Cow<'a, str>,
     /// The signature to verify, in hexadecimal.
-    pub signature: &'a str,
+    pub signature: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::channel_verify")]
     pub command: RequestMethod,
@@ -30,10 +31,10 @@ pub struct ChannelVerify<'a> {
 impl<'a> Default for ChannelVerify<'a> {
     fn default() -> Self {
         ChannelVerify {
-            channel_id: "",
-            amount: "",
-            public_key: "",
-            signature: "",
+            channel_id: "".into(),
+            amount: "".into(),
+            public_key: "".into(),
+            signature: "".into(),
             id: None,
             command: RequestMethod::ChannelVerify,
         }
@@ -44,11 +45,11 @@ impl<'a> Model for ChannelVerify<'a> {}
 
 impl<'a> ChannelVerify<'a> {
     pub fn new(
-        channel_id: &'a str,
-        amount: &'a str,
-        public_key: &'a str,
-        signature: &'a str,
-        id: Option<&'a str>,
+        channel_id: Cow<'a, str>,
+        amount: Cow<'a, str>,
+        public_key: Cow<'a, str>,
+        signature: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             channel_id,

--- a/src/models/requests/deposit_authorize.rs
+++ b/src/models/requests/deposit_authorize.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -12,16 +13,16 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct DepositAuthorized<'a> {
     /// The sender of a possible payment.
-    pub source_account: &'a str,
+    pub source_account: Cow<'a, str>,
     /// The recipient of a possible payment.
-    pub destination_account: &'a str,
+    pub destination_account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::deposit_authorization")]
     pub command: RequestMethod,
@@ -30,8 +31,8 @@ pub struct DepositAuthorized<'a> {
 impl<'a> Default for DepositAuthorized<'a> {
     fn default() -> Self {
         DepositAuthorized {
-            source_account: "",
-            destination_account: "",
+            source_account: "".into(),
+            destination_account: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -44,11 +45,11 @@ impl<'a> Model for DepositAuthorized<'a> {}
 
 impl<'a> DepositAuthorized<'a> {
     pub fn new(
-        source_account: &'a str,
-        destination_account: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        source_account: Cow<'a, str>,
+        destination_account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             source_account,

--- a/src/models/requests/exceptions.rs
+++ b/src/models/requests/exceptions.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use strum_macros::Display;
 use thiserror_no_std::Error;
 
@@ -18,11 +19,11 @@ pub enum XRPLChannelAuthorizeException<'a> {
     /// A field cannot be defined with other fields.
     #[error("The field `{field1:?}` can not be defined with `{field2:?}`, `{field3:?}`, `{field4:?}`. Define exactly one of them. For more information see: {resource:?}")]
     DefineExactlyOneOf {
-        field1: &'a str,
-        field2: &'a str,
-        field3: &'a str,
-        field4: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        field3: Cow<'a, str>,
+        field4: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -40,17 +41,17 @@ pub enum XRPLLedgerEntryException<'a> {
     /// A field cannot be defined with other fields.
     #[error("Define one of: `{field1:?}`, `{field2:?}`, `{field3:?}`, `{field4:?}`, `{field5:?}`, `{field6:?}`, `{field7:?}`, `{field8:?}`, `{field9:?}`, `{field10:?}`. Define exactly one of them. For more information see: {resource:?}")]
     DefineExactlyOneOf {
-        field1: &'a str,
-        field2: &'a str,
-        field3: &'a str,
-        field4: &'a str,
-        field5: &'a str,
-        field6: &'a str,
-        field7: &'a str,
-        field8: &'a str,
-        field9: &'a str,
-        field10: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        field3: Cow<'a, str>,
+        field4: Cow<'a, str>,
+        field5: Cow<'a, str>,
+        field6: Cow<'a, str>,
+        field7: Cow<'a, str>,
+        field8: Cow<'a, str>,
+        field9: Cow<'a, str>,
+        field10: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
 }
 

--- a/src/models/requests/fee.rs
+++ b/src/models/requests/fee.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -14,7 +15,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Fee<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::fee")]
     pub command: RequestMethod,
@@ -32,7 +33,7 @@ impl<'a> Default for Fee<'a> {
 impl<'a> Model for Fee<'a> {}
 
 impl<'a> Fee<'a> {
-    pub fn new(id: Option<&'a str>) -> Self {
+    pub fn new(id: Option<Cow<'a, str>>) -> Self {
         Self {
             id,
             command: RequestMethod::Fee,

--- a/src/models/requests/gateway_balances.rs
+++ b/src/models/requests/gateway_balances.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -14,20 +15,20 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct GatewayBalances<'a> {
     /// The Address to check. This should be the issuing address.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// If true, only accept an address or public key for the
     /// account parameter. Defaults to false.
     pub strict: Option<bool>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger version to use, or a
     /// shortcut string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// An operational address to exclude from the balances
     /// issued, or an array of such addresses.
-    pub hotwallet: Option<Vec<&'a str>>,
+    pub hotwallet: Option<Vec<Cow<'a, str>>>,
     /// The request method.
     #[serde(default = "RequestMethod::deposit_authorization")]
     pub command: RequestMethod,
@@ -36,7 +37,7 @@ pub struct GatewayBalances<'a> {
 impl<'a> Default for GatewayBalances<'a> {
     fn default() -> Self {
         GatewayBalances {
-            account: "",
+            account: "".into(),
             id: None,
             strict: None,
             ledger_hash: None,
@@ -51,12 +52,12 @@ impl<'a> Model for GatewayBalances<'a> {}
 
 impl<'a> GatewayBalances<'a> {
     pub fn new(
-        account: &'a str,
-        id: Option<&'a str>,
+        account: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
         strict: Option<bool>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
-        hotwallet: Option<Vec<&'a str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
+        hotwallet: Option<Vec<Cow<'a, str>>>,
     ) -> Self {
         Self {
             account,

--- a/src/models/requests/ledger.rs
+++ b/src/models/requests/ledger.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -11,12 +12,12 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Ledger<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// Admin required. If true, return full information on
     /// the entire ledger. Ignored if you did not specify a
     /// ledger version. Defaults to false. (Equivalent to
@@ -77,9 +78,9 @@ impl<'a> Model for Ledger<'a> {}
 
 impl<'a> Ledger<'a> {
     pub fn new(
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         full: Option<bool>,
         accounts: Option<bool>,
         transactions: Option<bool>,

--- a/src/models/requests/ledger_closed.rs
+++ b/src/models/requests/ledger_closed.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -13,7 +14,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct LedgerClosed<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::ledger_closed")]
     pub command: RequestMethod,
@@ -31,7 +32,7 @@ impl<'a> Default for LedgerClosed<'a> {
 impl<'a> Model for LedgerClosed<'a> {}
 
 impl<'a> LedgerClosed<'a> {
-    pub fn new(id: Option<&'a str>) -> Self {
+    pub fn new(id: Option<Cow<'a, str>>) -> Self {
         Self {
             id,
             command: RequestMethod::LedgerClosed,

--- a/src/models/requests/ledger_current.rs
+++ b/src/models/requests/ledger_current.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -13,7 +14,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct LedgerCurrent<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::ledger_current")]
     pub command: RequestMethod,
@@ -31,7 +32,7 @@ impl<'a> Default for LedgerCurrent<'a> {
 impl<'a> Model for LedgerCurrent<'a> {}
 
 impl<'a> LedgerCurrent<'a> {
-    pub fn new(id: Option<&'a str>) -> Self {
+    pub fn new(id: Option<Cow<'a, str>>) -> Self {
         Self {
             id,
             command: RequestMethod::LedgerCurrent,

--- a/src/models/requests/ledger_data.rs
+++ b/src/models/requests/ledger_data.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -13,12 +14,12 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct LedgerData<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// If set to true, return ledger objects as hashed hex
     /// strings instead of JSON.
     pub binary: Option<bool>,
@@ -51,9 +52,9 @@ impl<'a> Model for LedgerData<'a> {}
 
 impl<'a> LedgerData<'a> {
     pub fn new(
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         binary: Option<bool>,
         limit: Option<u16>,
         marker: Option<u32>,

--- a/src/models/requests/ledger_entry.rs
+++ b/src/models/requests/ledger_entry.rs
@@ -1,5 +1,6 @@
 use crate::Err;
 use anyhow::Result;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -10,8 +11,8 @@ use crate::models::{requests::RequestMethod, Model};
 /// querying by object ID.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct DepositPreauth<'a> {
-    pub owner: &'a str,
-    pub authorized: &'a str,
+    pub owner: Cow<'a, str>,
+    pub authorized: Cow<'a, str>,
 }
 
 /// Required fields for requesting a DirectoryNode if not
@@ -19,8 +20,8 @@ pub struct DepositPreauth<'a> {
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Directory<'a> {
-    pub owner: &'a str,
-    pub dir_root: &'a str,
+    pub owner: Cow<'a, str>,
+    pub dir_root: Cow<'a, str>,
     pub sub_index: Option<u8>,
 }
 
@@ -28,7 +29,7 @@ pub struct Directory<'a> {
 /// by object ID.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Escrow<'a> {
-    pub owner: &'a str,
+    pub owner: Cow<'a, str>,
     pub seq: u64,
 }
 
@@ -36,7 +37,7 @@ pub struct Escrow<'a> {
 /// by object ID.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Offer<'a> {
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     pub seq: u64,
 }
 
@@ -44,15 +45,15 @@ pub struct Offer<'a> {
 /// querying by object ID.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Ticket<'a> {
-    pub owner: &'a str,
+    pub owner: Cow<'a, str>,
     pub ticket_sequence: u64,
 }
 
 /// Required fields for requesting a RippleState.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct RippleState<'a> {
-    pub account: &'a str,
-    pub currency: &'a str,
+    pub account: Cow<'a, str>,
+    pub currency: Cow<'a, str>,
 }
 
 /// The ledger_entry method returns a single ledger object
@@ -69,11 +70,11 @@ pub struct RippleState<'a> {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct LedgerEntry<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
-    pub index: Option<&'a str>,
-    pub account_root: Option<&'a str>,
-    pub check: Option<&'a str>,
-    pub payment_channel: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
+    pub index: Option<Cow<'a, str>>,
+    pub account_root: Option<Cow<'a, str>>,
+    pub check: Option<Cow<'a, str>>,
+    pub payment_channel: Option<Cow<'a, str>>,
     pub deposit_preauth: Option<DepositPreauth<'a>>,
     pub directory: Option<Directory<'a>>,
     pub escrow: Option<Escrow<'a>>,
@@ -85,11 +86,11 @@ pub struct LedgerEntry<'a> {
     /// data in JSON format. The default is false.
     pub binary: Option<bool>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut string
     /// (e.g. "validated" or "closed" or "current") to choose a ledger
     /// automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::ledger_entry")]
     pub command: RequestMethod,
@@ -129,7 +130,7 @@ impl<'a: 'static> Model for LedgerEntry<'a> {
 impl<'a> LedgerEntryError for LedgerEntry<'a> {
     fn _get_field_error(&self) -> Result<(), XRPLLedgerEntryException> {
         let mut signing_methods: u32 = 0;
-        for method in [self.index, self.account_root, self.check] {
+        for method in [self.index.clone(), self.account_root.clone(), self.check.clone()] {
             if method.is_some() {
                 signing_methods += 1
             }
@@ -157,17 +158,17 @@ impl<'a> LedgerEntryError for LedgerEntry<'a> {
         }
         if signing_methods != 1 {
             Err(XRPLLedgerEntryException::DefineExactlyOneOf {
-                field1: "index",
-                field2: "account_root",
-                field3: "check",
-                field4: "directory",
-                field5: "offer",
-                field6: "ripple_state",
-                field7: "escrow",
-                field8: "payment_channel",
-                field9: "deposit_preauth",
-                field10: "ticket",
-                resource: "",
+                field1: "index".into(),
+                field2: "account_root".into(),
+                field3: "check".into(),
+                field4: "directory".into(),
+                field5: "offer".into(),
+                field6: "ripple_state".into(),
+                field7: "escrow".into(),
+                field8: "payment_channel".into(),
+                field9: "deposit_preauth".into(),
+                field10: "ticket".into(),
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -177,11 +178,11 @@ impl<'a> LedgerEntryError for LedgerEntry<'a> {
 
 impl<'a> LedgerEntry<'a> {
     pub fn new(
-        id: Option<&'a str>,
-        index: Option<&'a str>,
-        account_root: Option<&'a str>,
-        check: Option<&'a str>,
-        payment_channel: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
+        index: Option<Cow<'a, str>>,
+        account_root: Option<Cow<'a, str>>,
+        check: Option<Cow<'a, str>>,
+        payment_channel: Option<Cow<'a, str>>,
         deposit_preauth: Option<DepositPreauth<'a>>,
         directory: Option<Directory<'a>>,
         escrow: Option<Escrow<'a>>,
@@ -189,8 +190,8 @@ impl<'a> LedgerEntry<'a> {
         ripple_state: Option<RippleState<'a>>,
         ticket: Option<Ticket<'a>>,
         binary: Option<bool>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             id,
@@ -231,14 +232,14 @@ mod test_ledger_entry_errors {
             command: RequestMethod::LedgerEntry,
             id: None,
             index: None,
-            account_root: Some("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+            account_root: Some("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into()),
             check: None,
             payment_channel: None,
             deposit_preauth: None,
             directory: None,
             escrow: None,
             offer: Some(Offer {
-                account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
                 seq: 359,
             }),
             ripple_state: None,
@@ -248,17 +249,17 @@ mod test_ledger_entry_errors {
             ledger_index: None,
         };
         let _expected = XRPLLedgerEntryException::DefineExactlyOneOf {
-            field1: "index",
-            field2: "account_root",
-            field3: "check",
-            field4: "directory",
-            field5: "offer",
-            field6: "ripple_state",
-            field7: "escrow",
-            field8: "payment_channel",
-            field9: "deposit_preauth",
-            field10: "ticket",
-            resource: "",
+            field1: "index".into(),
+            field2: "account_root".into(),
+            field3: "check".into(),
+            field4: "directory".into(),
+            field5: "offer".into(),
+            field6: "ripple_state".into(),
+            field7: "escrow".into(),
+            field8: "payment_channel".into(),
+            field9: "deposit_preauth".into(),
+            field10: "ticket".into(),
+            resource: "".into(),
         };
         assert_eq!(
             ledger_entry.validate().unwrap_err().to_string().as_str(),

--- a/src/models/requests/ledger_entry.rs
+++ b/src/models/requests/ledger_entry.rs
@@ -1,6 +1,6 @@
 use crate::Err;
-use anyhow::Result;
 use alloc::borrow::Cow;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -130,7 +130,11 @@ impl<'a: 'static> Model for LedgerEntry<'a> {
 impl<'a> LedgerEntryError for LedgerEntry<'a> {
     fn _get_field_error(&self) -> Result<(), XRPLLedgerEntryException> {
         let mut signing_methods: u32 = 0;
-        for method in [self.index.clone(), self.account_root.clone(), self.check.clone()] {
+        for method in [
+            self.index.clone(),
+            self.account_root.clone(),
+            self.check.clone(),
+        ] {
             if method.is_some() {
                 signing_methods += 1
             }

--- a/src/models/requests/manifest.rs
+++ b/src/models/requests/manifest.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -16,9 +17,9 @@ pub struct Manifest<'a> {
     /// The base58-encoded public key of the validator
     /// to look up. This can be the master public key or
     /// ephemeral public key.
-    pub public_key: &'a str,
+    pub public_key: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::manifest")]
     pub command: RequestMethod,
@@ -27,7 +28,7 @@ pub struct Manifest<'a> {
 impl<'a> Default for Manifest<'a> {
     fn default() -> Self {
         Manifest {
-            public_key: "",
+            public_key: "".into(),
             id: None,
             command: RequestMethod::Manifest,
         }
@@ -37,7 +38,7 @@ impl<'a> Default for Manifest<'a> {
 impl<'a> Model for Manifest<'a> {}
 
 impl<'a> Manifest<'a> {
-    pub fn new(public_key: &'a str, id: Option<&'a str>) -> Self {
+    pub fn new(public_key: Cow<'a, str>, id: Option<Cow<'a, str>>) -> Self {
         Self {
             public_key,
             id,

--- a/src/models/requests/nft_buy_offers.rs
+++ b/src/models/requests/nft_buy_offers.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -8,12 +9,12 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct NftBuyOffers<'a> {
     /// The unique identifier of a NFToken object.
-    pub nft_id: &'a str,
+    pub nft_id: Cow<'a, str>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// Limit the number of NFT buy offers to retrieve.
     /// This value cannot be lower than 50 or more than 500.
     /// The default is 250.
@@ -29,7 +30,7 @@ pub struct NftBuyOffers<'a> {
 impl<'a> Default for NftBuyOffers<'a> {
     fn default() -> Self {
         NftBuyOffers {
-            nft_id: "",
+            nft_id: "".into(),
             ledger_hash: None,
             ledger_index: None,
             limit: None,
@@ -43,9 +44,9 @@ impl<'a> Model for NftBuyOffers<'a> {}
 
 impl<'a> NftBuyOffers<'a> {
     pub fn new(
-        nft_id: &'a str,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        nft_id: Cow<'a, str>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         limit: Option<u16>,
         marker: Option<u32>,
     ) -> Self {

--- a/src/models/requests/nft_sell_offers.rs
+++ b/src/models/requests/nft_sell_offers.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -8,7 +9,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct NftSellOffers<'a> {
     /// The unique identifier of a NFToken object.
-    pub nft_id: &'a str,
+    pub nft_id: Cow<'a, str>,
     /// The request method.
     #[serde(default = "RequestMethod::nft_sell_offers")]
     pub command: RequestMethod,
@@ -17,7 +18,7 @@ pub struct NftSellOffers<'a> {
 impl<'a> Default for NftSellOffers<'a> {
     fn default() -> Self {
         NftSellOffers {
-            nft_id: "",
+            nft_id: "".into(),
             command: RequestMethod::NftSellOffers,
         }
     }
@@ -26,7 +27,7 @@ impl<'a> Default for NftSellOffers<'a> {
 impl<'a> Model for NftSellOffers<'a> {}
 
 impl<'a> NftSellOffers<'a> {
-    pub fn new(nft_id: &'a str) -> Self {
+    pub fn new(nft_id: Cow<'a, str>) -> Self {
         Self {
             nft_id,
             command: RequestMethod::NftSellOffers,

--- a/src/models/requests/no_ripple_check.rs
+++ b/src/models/requests/no_ripple_check.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use strum_macros::Display;
@@ -29,7 +30,7 @@ pub enum NoRippleCheckRole {
 pub struct NoRippleCheck<'a> {
     /// A unique identifier for the account, most commonly the
     /// account's address.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Whether the address refers to a gateway or user.
     /// Recommendations depend on the role of the account.
     /// Issuers must have Default Ripple enabled and must disable
@@ -37,12 +38,12 @@ pub struct NoRippleCheck<'a> {
     /// disabled, and should enable No Ripple on all trust lines.
     pub role: NoRippleCheckRole,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut string
     /// to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// If true, include an array of suggested transactions, as JSON
     /// objects, that you can sign and submit to fix the problems.
     /// Defaults to false.
@@ -58,7 +59,7 @@ pub struct NoRippleCheck<'a> {
 impl<'a> Default for NoRippleCheck<'a> {
     fn default() -> Self {
         NoRippleCheck {
-            account: "",
+            account: "".into(),
             role: Default::default(),
             id: None,
             ledger_hash: None,
@@ -74,11 +75,11 @@ impl<'a> Model for NoRippleCheck<'a> {}
 
 impl<'a> NoRippleCheck<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         role: NoRippleCheckRole,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         transactions: Option<bool>,
         limit: Option<u16>,
     ) -> Self {

--- a/src/models/requests/path_find.rs
+++ b/src/models/requests/path_find.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -61,10 +62,10 @@ pub struct PathFind<'a> {
     /// Unique address of the account to find a path
     /// from. (In other words, the account that would
     /// be sending a payment.)
-    pub source_account: &'a str,
+    pub source_account: Cow<'a, str>,
     /// Unique address of the account to find a path to.
     /// (In other words, the account that would receive a payment.)
-    pub destination_account: &'a str,
+    pub destination_account: Cow<'a, str>,
     /// Currency Amount that the destination account would
     /// receive in a transaction. Special case: New in: rippled 0.30.0
     /// You can specify "-1" (for XRP) or provide -1 as the contents of
@@ -73,7 +74,7 @@ pub struct PathFind<'a> {
     /// the amount specified in send_max (if provided).
     pub destination_amount: Currency<'a>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// Currency Amount that would be spent in the transaction.
     /// Not compatible with source_currencies.
     pub send_max: Option<Currency<'a>>,
@@ -91,8 +92,8 @@ impl<'a> Default for PathFind<'a> {
     fn default() -> Self {
         PathFind {
             subcommand: Default::default(),
-            source_account: "",
-            destination_account: "",
+            source_account: "".into(),
+            destination_account: "".into(),
             destination_amount: Currency::XRP(XRP::new()),
             id: None,
             send_max: None,
@@ -107,10 +108,10 @@ impl<'a> Model for PathFind<'a> {}
 impl<'a> PathFind<'a> {
     pub fn new(
         subcommand: PathFindSubcommand,
-        source_account: &'a str,
-        destination_account: &'a str,
+        source_account: Cow<'a, str>,
+        destination_account: Cow<'a, str>,
         destination_amount: Currency<'a>,
-        id: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
         send_max: Option<Currency<'a>>,
         paths: Option<Vec<Vec<PathStep<'a>>>>,
     ) -> Self {

--- a/src/models/requests/ping.rs
+++ b/src/models/requests/ping.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -12,7 +13,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Ping<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::ping")]
     pub command: RequestMethod,
@@ -30,7 +31,7 @@ impl<'a> Default for Ping<'a> {
 impl<'a> Model for Ping<'a> {}
 
 impl<'a> Ping<'a> {
-    pub fn new(id: Option<&'a str>) -> Self {
+    pub fn new(id: Option<Cow<'a, str>>) -> Self {
         Self {
             id,
             command: RequestMethod::Ping,

--- a/src/models/requests/random.rs
+++ b/src/models/requests/random.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -13,7 +14,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Random<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::random")]
     pub command: RequestMethod,
@@ -31,7 +32,7 @@ impl<'a> Default for Random<'a> {
 impl<'a> Model for Random<'a> {}
 
 impl<'a> Random<'a> {
-    pub fn new(id: Option<&'a str>) -> Self {
+    pub fn new(id: Option<Cow<'a, str>>) -> Self {
         Self {
             id,
             command: RequestMethod::Random,

--- a/src/models/requests/ripple_path_find.rs
+++ b/src/models/requests/ripple_path_find.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -26,10 +27,10 @@ use crate::models::{currency::Currency, requests::RequestMethod, Model};
 pub struct RipplePathFind<'a> {
     /// Unique address of the account that would send funds
     /// in a transaction.
-    pub source_account: &'a str,
+    pub source_account: Cow<'a, str>,
     /// Unique address of the account that would receive funds
     /// in a transaction.
-    pub destination_account: &'a str,
+    pub destination_account: Cow<'a, str>,
     /// Currency Amount that the destination account would
     /// receive in a transaction. Special case: New in: rippled 0.30.0
     /// You can specify "-1" (for XRP) or provide -1 as the contents
@@ -38,12 +39,12 @@ pub struct RipplePathFind<'a> {
     /// than the amount specified in send_max (if provided).
     pub destination_amount: Currency<'a>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// Currency Amount that would be spent in the transaction.
     /// Cannot be used with source_currencies.
     pub send_max: Option<Currency<'a>>,
@@ -63,8 +64,8 @@ pub struct RipplePathFind<'a> {
 impl<'a> Default for RipplePathFind<'a> {
     fn default() -> Self {
         RipplePathFind {
-            source_account: "",
-            destination_account: "",
+            source_account: "".into(),
+            destination_account: "".into(),
             destination_amount: Currency::XRP(XRP::new()),
             id: None,
             ledger_hash: None,
@@ -80,12 +81,12 @@ impl<'a> Model for RipplePathFind<'a> {}
 
 impl<'a> RipplePathFind<'a> {
     pub fn new(
-        source_account: &'a str,
-        destination_account: &'a str,
+        source_account: Cow<'a, str>,
+        destination_account: Cow<'a, str>,
         destination_amount: Currency<'a>,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
         send_max: Option<Currency<'a>>,
         source_currencies: Option<Vec<Currency<'a>>>,
     ) -> Self {

--- a/src/models/requests/server_info.rs
+++ b/src/models/requests/server_info.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -13,7 +14,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct ServerInfo<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request info.
     #[serde(default = "RequestMethod::server_info")]
     pub command: RequestMethod,
@@ -31,7 +32,7 @@ impl<'a> Default for ServerInfo<'a> {
 impl<'a> Model for ServerInfo<'a> {}
 
 impl<'a> ServerInfo<'a> {
-    pub fn new(id: Option<&'a str>) -> Self {
+    pub fn new(id: Option<Cow<'a, str>>) -> Self {
         Self {
             id,
             command: RequestMethod::ServerInfo,

--- a/src/models/requests/server_state.rs
+++ b/src/models/requests/server_state.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -18,7 +19,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct ServerState<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::server_state")]
     pub command: RequestMethod,
@@ -36,7 +37,7 @@ impl<'a> Default for ServerState<'a> {
 impl<'a> Model for ServerState<'a> {}
 
 impl<'a> ServerState<'a> {
-    pub fn new(id: Option<&'a str>) -> Self {
+    pub fn new(id: Option<Cow<'a, str>>) -> Self {
         Self {
             id,
             command: RequestMethod::ServerState,

--- a/src/models/requests/submit.rs
+++ b/src/models/requests/submit.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -35,9 +36,9 @@ use crate::models::{requests::RequestMethod, Model};
 pub struct Submit<'a> {
     /// Hex representation of the signed transaction to submit.
     /// This can also be a multi-signed transaction.
-    pub tx_blob: &'a str,
+    pub tx_blob: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// If true, and the transaction fails locally, do not retry
     /// or relay the transaction to other servers
     pub fail_hard: Option<bool>,
@@ -49,7 +50,7 @@ pub struct Submit<'a> {
 impl<'a> Default for Submit<'a> {
     fn default() -> Self {
         Submit {
-            tx_blob: "",
+            tx_blob: "".into(),
             id: None,
             fail_hard: None,
             command: RequestMethod::Submit,
@@ -60,7 +61,7 @@ impl<'a> Default for Submit<'a> {
 impl<'a> Model for Submit<'a> {}
 
 impl<'a> Submit<'a> {
-    pub fn new(tx_blob: &'a str, id: Option<&'a str>, fail_hard: Option<bool>) -> Self {
+    pub fn new(tx_blob: Cow<'a, str>, id: Option<Cow<'a, str>>, fail_hard: Option<bool>) -> Self {
         Self {
             tx_blob,
             id,

--- a/src/models/requests/submit_multisigned.rs
+++ b/src/models/requests/submit_multisigned.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -18,7 +19,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct SubmitMultisigned<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// If true, and the transaction fails locally, do not
     /// retry or relay the transaction to other servers.
     pub fail_hard: Option<bool>,
@@ -40,7 +41,7 @@ impl<'a> Default for SubmitMultisigned<'a> {
 impl<'a> Model for SubmitMultisigned<'a> {}
 
 impl<'a> SubmitMultisigned<'a> {
-    pub fn new(id: Option<&'a str>, fail_hard: Option<bool>) -> Self {
+    pub fn new(id: Option<Cow<'a, str>>, fail_hard: Option<bool>) -> Self {
         Self {
             id,
             fail_hard,

--- a/src/models/requests/subscribe.rs
+++ b/src/models/requests/subscribe.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -14,7 +15,7 @@ use crate::models::{currency::Currency, default_false, requests::RequestMethod, 
 pub struct SubscribeBook<'a> {
     pub taker_gets: Currency<'a>,
     pub taker_pays: Currency<'a>,
-    pub taker: &'a str,
+    pub taker: Cow<'a, str>,
     #[serde(default = "default_false")]
     pub snapshot: Option<bool>,
     #[serde(default = "default_false")]
@@ -47,7 +48,7 @@ pub enum StreamParameter {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Subscribe<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// Array of objects defining order books  to monitor for
     /// updates, as detailed below.
     pub books: Option<Vec<SubscribeBook<'a>>>,
@@ -57,17 +58,17 @@ pub struct Subscribe<'a> {
     /// for validated transactions. The addresses must be in the
     /// XRP Ledger's base58 format. The server sends a notification
     /// for any transaction that affects at least one of these accounts.
-    pub accounts: Option<Vec<&'a str>>,
+    pub accounts: Option<Vec<Cow<'a, str>>>,
     /// Like accounts, but include transactions that are not
     /// yet finalized.
-    pub accounts_proposed: Option<Vec<&'a str>>,
+    pub accounts_proposed: Option<Vec<Cow<'a, str>>>,
     /// (Optional for Websocket; Required otherwise) URL where the server
     /// sends a JSON-RPC callbacks for each event. Admin-only.
-    pub url: Option<&'a str>,
+    pub url: Option<Cow<'a, str>>,
     /// Username to provide for basic authentication at the callback URL.
-    pub url_username: Option<&'a str>,
+    pub url_username: Option<Cow<'a, str>>,
     /// Password to provide for basic authentication at the callback URL.
-    pub url_password: Option<&'a str>,
+    pub url_password: Option<Cow<'a, str>>,
     /// The request method.
     // #[serde(skip_serializing)]
     #[serde(default = "RequestMethod::subscribe")]
@@ -94,14 +95,14 @@ impl<'a> Model for Subscribe<'a> {}
 
 impl<'a> Subscribe<'a> {
     pub fn new(
-        id: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
         books: Option<Vec<SubscribeBook<'a>>>,
         streams: Option<Vec<StreamParameter>>,
-        accounts: Option<Vec<&'a str>>,
-        accounts_proposed: Option<Vec<&'a str>>,
-        url: Option<&'a str>,
-        url_username: Option<&'a str>,
-        url_password: Option<&'a str>,
+        accounts: Option<Vec<Cow<'a, str>>>,
+        accounts_proposed: Option<Vec<Cow<'a, str>>>,
+        url: Option<Cow<'a, str>>,
+        url_username: Option<Cow<'a, str>>,
+        url_password: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             id,

--- a/src/models/requests/transaction_entry.rs
+++ b/src/models/requests/transaction_entry.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -15,14 +16,14 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct TransactionEntry<'a> {
     /// Unique hash of the transaction you are looking up.
-    pub tx_hash: &'a str,
+    pub tx_hash: Cow<'a, str>,
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// A 20-byte hex string for the ledger version to use.
-    pub ledger_hash: Option<&'a str>,
+    pub ledger_hash: Option<Cow<'a, str>>,
     /// The ledger index of the ledger to use, or a shortcut
     /// string to choose a ledger automatically.
-    pub ledger_index: Option<&'a str>,
+    pub ledger_index: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::transaction_entry")]
     pub command: RequestMethod,
@@ -31,7 +32,7 @@ pub struct TransactionEntry<'a> {
 impl<'a> Default for TransactionEntry<'a> {
     fn default() -> Self {
         TransactionEntry {
-            tx_hash: "",
+            tx_hash: "".into(),
             id: None,
             ledger_hash: None,
             ledger_index: None,
@@ -44,10 +45,10 @@ impl<'a> Model for TransactionEntry<'a> {}
 
 impl<'a> TransactionEntry<'a> {
     pub fn new(
-        tx_hash: &'a str,
-        id: Option<&'a str>,
-        ledger_hash: Option<&'a str>,
-        ledger_index: Option<&'a str>,
+        tx_hash: Cow<'a, str>,
+        id: Option<Cow<'a, str>>,
+        ledger_hash: Option<Cow<'a, str>>,
+        ledger_index: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             tx_hash,

--- a/src/models/requests/tx.rs
+++ b/src/models/requests/tx.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -11,7 +12,7 @@ use crate::models::{requests::RequestMethod, Model};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Tx<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// If true, return transaction data and metadata as binary
     /// serialized to hexadecimal strings. If false, return
     /// transaction data and metadata as JSON. The default is false.
@@ -47,7 +48,7 @@ impl<'a> Model for Tx<'a> {}
 
 impl<'a> Tx<'a> {
     pub fn new(
-        id: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
         binary: Option<bool>,
         min_ledger: Option<u32>,
         max_ledger: Option<u32>,

--- a/src/models/requests/unsubscribe.rs
+++ b/src/models/requests/unsubscribe.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -34,7 +35,7 @@ pub struct UnsubscribeBook<'a> {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Unsubscribe<'a> {
     /// The unique request id.
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
     /// Array of objects defining order books to unsubscribe
     /// from, as explained below.
     pub books: Option<Vec<UnsubscribeBook<'a>>>,
@@ -47,12 +48,12 @@ pub struct Unsubscribe<'a> {
     /// those messages if you previously subscribed to those accounts
     /// specifically. You cannot use this to filter accounts out of
     /// the general transactions stream.)
-    pub accounts: Option<Vec<&'a str>>,
+    pub accounts: Option<Vec<Cow<'a, str>>>,
     /// Like accounts, but for accounts_proposed subscriptions that
     /// included not-yet-validated transactions.
-    pub accounts_proposed: Option<Vec<&'a str>>,
+    pub accounts_proposed: Option<Vec<Cow<'a, str>>>,
     #[serde(skip_serializing)]
-    pub broken: Option<&'a str>,
+    pub broken: Option<Cow<'a, str>>,
     /// The request method.
     #[serde(default = "RequestMethod::unsubscribe")]
     pub command: RequestMethod,
@@ -76,12 +77,12 @@ impl<'a> Model for Unsubscribe<'a> {}
 
 impl<'a> Unsubscribe<'a> {
     pub fn new(
-        id: Option<&'a str>,
+        id: Option<Cow<'a, str>>,
         books: Option<Vec<UnsubscribeBook<'a>>>,
         streams: Option<Vec<StreamParameter>>,
-        accounts: Option<Vec<&'a str>>,
-        accounts_proposed: Option<Vec<&'a str>>,
-        broken: Option<&'a str>,
+        accounts: Option<Vec<Cow<'a, str>>>,
+        accounts_proposed: Option<Vec<Cow<'a, str>>>,
+        broken: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             id,

--- a/src/models/transactions/account_delete.rs
+++ b/src/models/transactions/account_delete.rs
@@ -70,7 +70,7 @@ pub struct AccountDelete<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -132,7 +132,7 @@ impl<'a> AccountDelete<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         destination_tag: Option<u32>,
     ) -> Self {

--- a/src/models/transactions/account_delete.rs
+++ b/src/models/transactions/account_delete.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/account_delete.rs
+++ b/src/models/transactions/account_delete.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -30,7 +31,7 @@ pub struct AccountDelete<'a> {
     #[serde(default = "TransactionType::account_set")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -50,11 +51,11 @@ pub struct AccountDelete<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -66,7 +67,7 @@ pub struct AccountDelete<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -83,7 +84,7 @@ pub struct AccountDelete<'a> {
     /// The address of an account to receive any leftover XRP after
     /// deleting the sending account. Must be a funded account in
     /// the ledger, and must not be the sending account.
-    pub destination: &'a str,
+    pub destination: Cow<'a, str>,
     /// Arbitrary destination tag that identifies a hosted
     /// recipient or other information for the recipient
     /// of the deleted account's leftover XRP.
@@ -122,16 +123,16 @@ impl<'a> Transaction for AccountDelete<'a> {
 
 impl<'a> AccountDelete<'a> {
     pub fn new(
-        account: &'a str,
-        destination: &'a str,
+        account: Cow<'a, str>,
+        destination: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         destination_tag: Option<u32>,
@@ -163,8 +164,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = AccountDelete::new(
-            "rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm",
-            "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+            "rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm".into(),
+            "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe".into(),
             Some("2000000".into()),
             Some(2470665),
             None,
@@ -188,8 +189,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = AccountDelete::new(
-            "rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm",
-            "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+            "rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm".into(),
+            "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe".into(),
             Some("2000000".into()),
             Some(2470665),
             None,

--- a/src/models/transactions/account_set.rs
+++ b/src/models/transactions/account_set.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -84,7 +85,7 @@ pub struct AccountSet<'a> {
     #[serde(default = "TransactionType::account_set")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -104,11 +105,11 @@ pub struct AccountSet<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -120,7 +121,7 @@ pub struct AccountSet<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     #[serde(default)]
     #[serde(with = "txn_flags")]
@@ -141,22 +142,22 @@ pub struct AccountSet<'a> {
     /// The domain that owns this account, as a string of hex
     /// representing the ASCII for the domain in lowercase.
     /// Cannot be more than 256 bytes in length.
-    pub domain: Option<&'a str>,
+    pub domain: Option<Cow<'a, str>>,
     /// Hash of an email address to be used for generating an
     /// avatar image. Conventionally, clients use Gravatar
     /// to display this image.
-    pub email_hash: Option<&'a str>,
+    pub email_hash: Option<Cow<'a, str>>,
     /// Public key for sending encrypted messages to this account.
     /// To set the key, it must be exactly 33 bytes, with the
     /// first byte indicating the key type: 0x02 or 0x03 for
     /// secp256k1 keys, 0xED for Ed25519 keys. To remove the
     /// key, use an empty value.
-    pub message_key: Option<&'a str>,
+    pub message_key: Option<Cow<'a, str>>,
     /// Sets an alternate account that is allowed to mint NFTokens
     /// on this account's behalf using NFTokenMint's Issuer field.
     /// This field is part of the experimental XLS-20 standard
     /// for non-fungible tokens.
-    pub nftoken_minter: Option<&'a str>,
+    pub nftoken_minter: Option<Cow<'a, str>>,
     /// Flag to enable for this account.
     pub set_flag: Option<AccountSetFlag>,
     /// The fee to charge when users transfer this account's tokens,
@@ -261,17 +262,17 @@ impl<'a> AccountSetError for AccountSet<'a> {
         if let Some(tick_size) = self.tick_size {
             if tick_size > MAX_TICK_SIZE {
                 Err(XRPLAccountSetException::ValueTooHigh {
-                    field: "tick_size",
+                    field: "tick_size".into(),
                     max: MAX_TICK_SIZE,
                     found: tick_size,
-                    resource: "",
+                    resource: "".into(),
                 })
             } else if tick_size < MIN_TICK_SIZE && tick_size != DISABLE_TICK_SIZE {
                 Err(XRPLAccountSetException::ValueTooLow {
-                    field: "tick_size",
+                    field: "tick_size".into(),
                     min: MIN_TICK_SIZE,
                     found: tick_size,
-                    resource: "",
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -285,19 +286,19 @@ impl<'a> AccountSetError for AccountSet<'a> {
         if let Some(transfer_rate) = self.transfer_rate {
             if transfer_rate > MAX_TRANSFER_RATE {
                 Err(XRPLAccountSetException::ValueTooHigh {
-                    field: "transfer_rate",
+                    field: "transfer_rate".into(),
                     max: MAX_TRANSFER_RATE,
                     found: transfer_rate,
-                    resource: "",
+                    resource: "".into(),
                 })
             } else if transfer_rate < MIN_TRANSFER_RATE
                 && transfer_rate != SPECIAL_CASE_TRANFER_RATE
             {
                 Err(XRPLAccountSetException::ValueTooLow {
-                    field: "transfer_rate",
+                    field: "transfer_rate".into(),
                     min: MIN_TRANSFER_RATE,
                     found: transfer_rate,
-                    resource: "",
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -308,20 +309,20 @@ impl<'a> AccountSetError for AccountSet<'a> {
     }
 
     fn _get_domain_error(&self) -> Result<(), XRPLAccountSetException> {
-        if let Some(domain) = self.domain {
+        if let Some(domain) = self.domain.clone() {
             if domain.to_lowercase().as_str() != domain {
                 Err(XRPLAccountSetException::InvalidValueFormat {
-                    field: "domain",
+                    field: "domain".into(),
                     found: domain,
-                    format: "lowercase",
-                    resource: "",
+                    format: "lowercase".into(),
+                    resource: "".into(),
                 })
             } else if domain.len() > MAX_DOMAIN_LENGTH {
                 Err(XRPLAccountSetException::ValueTooLong {
-                    field: "domain",
+                    field: "domain".into(),
                     max: MAX_DOMAIN_LENGTH,
                     found: domain.len(),
-                    resource: "",
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -336,7 +337,7 @@ impl<'a> AccountSetError for AccountSet<'a> {
         {
             Err(XRPLAccountSetException::SetAndUnsetSameFlag {
                 found: self.clear_flag.clone().unwrap(),
-                resource: "",
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -344,24 +345,24 @@ impl<'a> AccountSetError for AccountSet<'a> {
     }
 
     fn _get_nftoken_minter_error(&self) -> Result<(), XRPLAccountSetException> {
-        if let Some(_nftoken_minter) = self.nftoken_minter {
+        if let Some(_nftoken_minter) = self.nftoken_minter.clone() {
             if self.set_flag.is_none() {
                 if let Some(clear_flag) = &self.clear_flag {
                     match clear_flag {
                         AccountSetFlag::AsfAuthorizedNFTokenMinter => {
                             Err(XRPLAccountSetException::SetFieldWhenUnsetRequiredFlag {
-                                field: "nftoken_minter",
+                                field: "nftoken_minter".into(),
                                 flag: AccountSetFlag::AsfAuthorizedNFTokenMinter,
-                                resource: "",
+                                resource: "".into(),
                             })
                         }
                         _ => Ok(()),
                     }
                 } else {
                     Err(XRPLAccountSetException::FieldRequiresFlag {
-                        field: "set_flag",
+                        field: "set_flag".into(),
                         flag: AccountSetFlag::AsfAuthorizedNFTokenMinter,
-                        resource: "",
+                        resource: "".into(),
                     })
                 }
             } else {
@@ -372,8 +373,8 @@ impl<'a> AccountSetError for AccountSet<'a> {
                 AccountSetFlag::AsfAuthorizedNFTokenMinter => {
                     Err(XRPLAccountSetException::FlagRequiresField {
                         flag: AccountSetFlag::AsfAuthorizedNFTokenMinter,
-                        field: "nftoken_minter",
-                        resource: "",
+                        field: "nftoken_minter".into(),
+                        resource: "".into(),
                     })
                 }
                 _ => Ok(()),
@@ -386,26 +387,26 @@ impl<'a> AccountSetError for AccountSet<'a> {
 
 impl<'a> AccountSet<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         flags: Option<Vec<AccountSetFlag>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         clear_flag: Option<AccountSetFlag>,
-        domain: Option<&'a str>,
-        email_hash: Option<&'a str>,
-        message_key: Option<&'a str>,
+        domain: Option<Cow<'a, str>>,
+        email_hash: Option<Cow<'a, str>>,
+        message_key: Option<Cow<'a, str>>,
         set_flag: Option<AccountSetFlag>,
         transfer_rate: Option<u32>,
         tick_size: Option<u32>,
-        nftoken_minter: Option<&'a str>,
+        nftoken_minter: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::AccountSet,
@@ -453,7 +454,7 @@ mod test_account_set_errors {
     fn test_tick_size_error() {
         let mut account_set = AccountSet {
             transaction_type: TransactionType::AccountSet,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -495,7 +496,7 @@ mod test_account_set_errors {
     fn test_transfer_rate_error() {
         let mut account_set = AccountSet {
             transaction_type: TransactionType::AccountSet,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -537,7 +538,7 @@ mod test_account_set_errors {
     fn test_domain_error() {
         let mut account_set = AccountSet {
             transaction_type: TransactionType::AccountSet,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -558,7 +559,7 @@ mod test_account_set_errors {
             tick_size: None,
             nftoken_minter: None,
         };
-        let domain_not_lowercase = Some("https://Example.com/");
+        let domain_not_lowercase = Some("https://Example.com/".into());
         account_set.domain = domain_not_lowercase;
 
         assert_eq!(
@@ -566,7 +567,7 @@ mod test_account_set_errors {
             "The value of the field `domain` does not have the correct format (expected lowercase, found https://Example.com/). For more information see: "
         );
 
-        let domain_too_long = Some("https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let domain_too_long = Some("https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into());
         account_set.domain = domain_too_long;
 
         assert_eq!(
@@ -579,7 +580,7 @@ mod test_account_set_errors {
     fn test_flag_error() {
         let account_set = AccountSet {
             transaction_type: TransactionType::AccountSet,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -611,7 +612,7 @@ mod test_account_set_errors {
     fn test_asf_authorized_nftoken_minter_error() {
         let mut account_set = AccountSet {
             transaction_type: TransactionType::AccountSet,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -632,7 +633,7 @@ mod test_account_set_errors {
             tick_size: None,
             nftoken_minter: None,
         };
-        account_set.nftoken_minter = Some("rLSn6Z3T8uCxbcd1oxwfGQN1Fdn5CyGujK");
+        account_set.nftoken_minter = Some("rLSn6Z3T8uCxbcd1oxwfGQN1Fdn5CyGujK".into());
 
         assert_eq!(
             account_set.validate().unwrap_err().to_string().as_str(),
@@ -648,7 +649,7 @@ mod test_account_set_errors {
         );
 
         account_set.set_flag = None;
-        account_set.nftoken_minter = Some("rLSn6Z3T8uCxbcd1oxwfGQN1Fdn5CyGujK");
+        account_set.nftoken_minter = Some("rLSn6Z3T8uCxbcd1oxwfGQN1Fdn5CyGujK".into());
         account_set.clear_flag = Some(AccountSetFlag::AsfAuthorizedNFTokenMinter);
 
         assert_eq!(
@@ -665,7 +666,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = AccountSet::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             Some("12".into()),
             Some(5),
             None,
@@ -678,9 +679,9 @@ mod test_serde {
             None,
             None,
             None,
-            Some("6578616D706C652E636F6D"),
+            Some("6578616D706C652E636F6D".into()),
             None,
-            Some("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB"),
+            Some("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB".into()),
             Some(AccountSetFlag::AsfAccountTxnID),
             None,
             None,
@@ -697,7 +698,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = AccountSet::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             Some("12".into()),
             Some(5),
             None,
@@ -710,9 +711,9 @@ mod test_serde {
             None,
             None,
             None,
-            Some("6578616D706C652E636F6D"),
+            Some("6578616D706C652E636F6D".into()),
             None,
-            Some("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB"),
+            Some("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB".into()),
             Some(AccountSetFlag::AsfAccountTxnID),
             None,
             None,

--- a/src/models/transactions/account_set.rs
+++ b/src/models/transactions/account_set.rs
@@ -126,7 +126,7 @@ pub struct AccountSet<'a> {
     #[serde(with = "txn_flags")]
     pub flags: Option<Vec<AccountSetFlag>>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -396,7 +396,7 @@ impl<'a> AccountSet<'a> {
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
         flags: Option<Vec<AccountSetFlag>>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         clear_flag: Option<AccountSetFlag>,
         domain: Option<&'a str>,

--- a/src/models/transactions/account_set.rs
+++ b/src/models/transactions/account_set.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};

--- a/src/models/transactions/check_cancel.rs
+++ b/src/models/transactions/check_cancel.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -30,7 +31,7 @@ pub struct CheckCancel<'a> {
     #[serde(default = "TransactionType::check_cancel")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -50,11 +51,11 @@ pub struct CheckCancel<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -66,7 +67,7 @@ pub struct CheckCancel<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -81,7 +82,7 @@ pub struct CheckCancel<'a> {
     // See CheckCancel fields:
     // `<https://xrpl.org/checkcancel.html#checkcancel-fields>`
     #[serde(rename = "CheckID")]
-    pub check_id: &'a str,
+    pub check_id: Cow<'a, str>,
 }
 
 impl<'a> Default for CheckCancel<'a> {
@@ -115,16 +116,16 @@ impl<'a> Transaction for CheckCancel<'a> {
 
 impl<'a> CheckCancel<'a> {
     pub fn new(
-        account: &'a str,
-        check_id: &'a str,
+        account: Cow<'a, str>,
+        check_id: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
@@ -154,8 +155,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = CheckCancel::new(
-            "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
-            "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0",
+            "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo".into(),
+            "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0".into(),
             Some("12".into()),
             None,
             None,
@@ -178,8 +179,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = CheckCancel::new(
-            "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
-            "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0",
+            "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo".into(),
+            "49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0".into(),
             Some("12".into()),
             None,
             None,

--- a/src/models/transactions/check_cancel.rs
+++ b/src/models/transactions/check_cancel.rs
@@ -70,7 +70,7 @@ pub struct CheckCancel<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -125,7 +125,7 @@ impl<'a> CheckCancel<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
         Self {

--- a/src/models/transactions/check_cancel.rs
+++ b/src/models/transactions/check_cancel.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/check_cash.rs
+++ b/src/models/transactions/check_cash.rs
@@ -74,7 +74,7 @@ pub struct CheckCash<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -156,7 +156,7 @@ impl<'a> CheckCash<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         amount: Option<Amount<'a>>,
         deliver_min: Option<Amount<'a>>,

--- a/src/models/transactions/check_cash.rs
+++ b/src/models/transactions/check_cash.rs
@@ -1,6 +1,6 @@
 use crate::Err;
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/src/models/transactions/check_cash.rs
+++ b/src/models/transactions/check_cash.rs
@@ -1,5 +1,6 @@
 use crate::Err;
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -34,7 +35,7 @@ pub struct CheckCash<'a> {
     #[serde(default = "TransactionType::check_cash")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -54,11 +55,11 @@ pub struct CheckCash<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -70,7 +71,7 @@ pub struct CheckCash<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -85,7 +86,7 @@ pub struct CheckCash<'a> {
     /// See CheckCash fields:
     /// `<https://xrpl.org/checkcash.html#checkcash-fields>`
     #[serde(rename = "CheckID")]
-    pub check_id: &'a str,
+    pub check_id: Cow<'a, str>,
     pub amount: Option<Amount<'a>>,
     pub deliver_min: Option<Amount<'a>>,
 }
@@ -134,9 +135,9 @@ impl<'a> CheckCashError for CheckCash<'a> {
             || (self.amount.is_some() && self.deliver_min.is_some())
         {
             Err(XRPLCheckCashException::DefineExactlyOneOf {
-                field1: "amount",
-                field2: "deliver_min",
-                resource: "",
+                field1: "amount".into(),
+                field2: "deliver_min".into(),
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -146,16 +147,16 @@ impl<'a> CheckCashError for CheckCash<'a> {
 
 impl<'a> CheckCash<'a> {
     pub fn new(
-        account: &'a str,
-        check_id: &'a str,
+        account: Cow<'a, str>,
+        check_id: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         amount: Option<Amount<'a>>,
@@ -197,7 +198,7 @@ mod test_check_cash_error {
     fn test_amount_and_deliver_min_error() {
         let check_cash = CheckCash {
             transaction_type: TransactionType::CheckCash,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -209,7 +210,7 @@ mod test_check_cash_error {
             flags: None,
             memos: None,
             signers: None,
-            check_id: "",
+            check_id: "".into(),
             amount: None,
             deliver_min: None,
         };
@@ -230,8 +231,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = CheckCash::new(
-            "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy",
-            "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334",
+            "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy".into(),
+            "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334".into(),
             Some("12".into()),
             None,
             None,
@@ -256,8 +257,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = CheckCash::new(
-            "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy",
-            "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334",
+            "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy".into(),
+            "838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334".into(),
             Some("12".into()),
             None,
             None,

--- a/src/models/transactions/check_create.rs
+++ b/src/models/transactions/check_create.rs
@@ -69,7 +69,7 @@ pub struct CheckCreate<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -133,7 +133,7 @@ impl<'a> CheckCreate<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         destination_tag: Option<u32>,
         expiration: Option<u32>,

--- a/src/models/transactions/check_create.rs
+++ b/src/models/transactions/check_create.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/check_create.rs
+++ b/src/models/transactions/check_create.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -29,7 +30,7 @@ pub struct CheckCreate<'a> {
     #[serde(default = "TransactionType::check_create")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -49,11 +50,11 @@ pub struct CheckCreate<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -65,7 +66,7 @@ pub struct CheckCreate<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -79,12 +80,12 @@ pub struct CheckCreate<'a> {
     ///
     /// See CheckCreate fields:
     /// `<https://xrpl.org/checkcreate.html#checkcreate-fields>`
-    pub destination: &'a str,
+    pub destination: Cow<'a, str>,
     pub send_max: Amount<'a>,
     pub destination_tag: Option<u32>,
     pub expiration: Option<u32>,
     #[serde(rename = "InvoiceID")]
-    pub invoice_id: Option<&'a str>,
+    pub invoice_id: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for CheckCreate<'a> {
@@ -122,22 +123,22 @@ impl<'a> Transaction for CheckCreate<'a> {
 
 impl<'a> CheckCreate<'a> {
     pub fn new(
-        account: &'a str,
-        destination: &'a str,
+        account: Cow<'a, str>,
+        destination: Cow<'a, str>,
         send_max: Amount<'a>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         destination_tag: Option<u32>,
         expiration: Option<u32>,
-        invoice_id: Option<&'a str>,
+        invoice_id: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::CheckCreate,
@@ -171,8 +172,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = CheckCreate::new(
-            "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
-            "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy",
+            "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo".into(),
+            "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy".into(),
             Amount::XRPAmount(XRPAmount::from("100000000")),
             Some("12".into()),
             None,
@@ -186,7 +187,7 @@ mod test_serde {
             None,
             Some(1),
             Some(570113521),
-            Some("6F1DFD1D0FE8A32E40E1F2C05CF1C15545BAB56B617F9C6C2D63A6B704BEF59B"),
+            Some("6F1DFD1D0FE8A32E40E1F2C05CF1C15545BAB56B617F9C6C2D63A6B704BEF59B".into()),
         );
         let default_json = r#"{"TransactionType":"CheckCreate","Account":"rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo","Fee":"12","Destination":"rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy","SendMax":"100000000","DestinationTag":1,"Expiration":570113521,"InvoiceID":"6F1DFD1D0FE8A32E40E1F2C05CF1C15545BAB56B617F9C6C2D63A6B704BEF59B"}"#;
 
@@ -199,8 +200,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = CheckCreate::new(
-            "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo",
-            "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy",
+            "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo".into(),
+            "rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy".into(),
             Amount::XRPAmount(XRPAmount::from("100000000")),
             Some("12".into()),
             None,
@@ -214,7 +215,7 @@ mod test_serde {
             None,
             Some(1),
             Some(570113521),
-            Some("6F1DFD1D0FE8A32E40E1F2C05CF1C15545BAB56B617F9C6C2D63A6B704BEF59B"),
+            Some("6F1DFD1D0FE8A32E40E1F2C05CF1C15545BAB56B617F9C6C2D63A6B704BEF59B".into()),
         );
         let default_json = r#"{"TransactionType":"CheckCreate","Account":"rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo","Destination":"rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy","SendMax":"100000000","Expiration":570113521,"InvoiceID":"6F1DFD1D0FE8A32E40E1F2C05CF1C15545BAB56B617F9C6C2D63A6B704BEF59B","DestinationTag":1,"Fee":"12"}"#;
 

--- a/src/models/transactions/deposit_preauth.rs
+++ b/src/models/transactions/deposit_preauth.rs
@@ -1,5 +1,6 @@
 use crate::Err;
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -31,7 +32,7 @@ pub struct DepositPreauth<'a> {
     #[serde(default = "TransactionType::deposit_preauth")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -51,11 +52,11 @@ pub struct DepositPreauth<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -67,7 +68,7 @@ pub struct DepositPreauth<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -81,8 +82,8 @@ pub struct DepositPreauth<'a> {
     ///
     /// See DepositPreauth fields:
     /// `<https://xrpl.org/depositpreauth.html#depositpreauth-fields>`
-    pub authorize: Option<&'a str>,
-    pub unauthorize: Option<&'a str>,
+    pub authorize: Option<Cow<'a, str>>,
+    pub unauthorize: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for DepositPreauth<'a> {
@@ -128,9 +129,9 @@ impl<'a> DepositPreauthError for DepositPreauth<'a> {
             || (self.authorize.is_some() && self.unauthorize.is_some())
         {
             Err(XRPLDepositPreauthException::DefineExactlyOneOf {
-                field1: "authorize",
-                field2: "unauthorize",
-                resource: "",
+                field1: "authorize".into(),
+                field2: "unauthorize".into(),
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -140,19 +141,19 @@ impl<'a> DepositPreauthError for DepositPreauth<'a> {
 
 impl<'a> DepositPreauth<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
-        authorize: Option<&'a str>,
-        unauthorize: Option<&'a str>,
+        authorize: Option<Cow<'a, str>>,
+        unauthorize: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::DepositPreauth,
@@ -190,7 +191,7 @@ mod test_deposit_preauth_exception {
     fn test_authorize_and_unauthorize_error() {
         let deposit_preauth = DepositPreauth {
             transaction_type: TransactionType::DepositPreauth,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -220,7 +221,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = DepositPreauth::new(
-            "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+            "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8".into(),
             Some("10".into()),
             Some(2),
             None,
@@ -231,7 +232,7 @@ mod test_serde {
             None,
             None,
             None,
-            Some("rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de"),
+            Some("rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de".into()),
             None,
         );
         let default_json = r#"{"TransactionType":"DepositPreauth","Account":"rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8","Fee":"10","Sequence":2,"Authorize":"rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de"}"#;
@@ -245,7 +246,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = DepositPreauth::new(
-            "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+            "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8".into(),
             Some("10".into()),
             Some(2),
             None,
@@ -256,7 +257,7 @@ mod test_serde {
             None,
             None,
             None,
-            Some("rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de"),
+            Some("rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de".into()),
             None,
         );
         let default_json = r#"{"TransactionType":"DepositPreauth","Account":"rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8","Authorize":"rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de","Fee":"10","Sequence":2}"#;

--- a/src/models/transactions/deposit_preauth.rs
+++ b/src/models/transactions/deposit_preauth.rs
@@ -1,6 +1,6 @@
 use crate::Err;
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;

--- a/src/models/transactions/deposit_preauth.rs
+++ b/src/models/transactions/deposit_preauth.rs
@@ -71,7 +71,7 @@ pub struct DepositPreauth<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -149,7 +149,7 @@ impl<'a> DepositPreauth<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         authorize: Option<&'a str>,
         unauthorize: Option<&'a str>,

--- a/src/models/transactions/escrow_cancel.rs
+++ b/src/models/transactions/escrow_cancel.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/escrow_cancel.rs
+++ b/src/models/transactions/escrow_cancel.rs
@@ -67,7 +67,7 @@ pub struct EscrowCancel<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -124,7 +124,7 @@ impl<'a> EscrowCancel<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
         Self {

--- a/src/models/transactions/escrow_cancel.rs
+++ b/src/models/transactions/escrow_cancel.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -27,7 +28,7 @@ pub struct EscrowCancel<'a> {
     #[serde(default = "TransactionType::escrow_cancel")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -47,11 +48,11 @@ pub struct EscrowCancel<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -63,7 +64,7 @@ pub struct EscrowCancel<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -77,7 +78,7 @@ pub struct EscrowCancel<'a> {
     ///
     /// See EscrowCancel fields:
     /// `<https://xrpl.org/escrowcancel.html#escrowcancel-flags>`
-    pub owner: &'a str,
+    pub owner: Cow<'a, str>,
     pub offer_sequence: u32,
 }
 
@@ -113,17 +114,17 @@ impl<'a> Transaction for EscrowCancel<'a> {
 
 impl<'a> EscrowCancel<'a> {
     pub fn new(
-        account: &'a str,
-        owner: &'a str,
+        account: Cow<'a, str>,
+        owner: Cow<'a, str>,
         offer_sequence: u32,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
@@ -154,8 +155,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = EscrowCancel::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             7,
             None,
             None,
@@ -179,8 +180,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = EscrowCancel::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             7,
             None,
             None,

--- a/src/models/transactions/escrow_create.rs
+++ b/src/models/transactions/escrow_create.rs
@@ -1,5 +1,6 @@
 use crate::Err;
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -30,7 +31,7 @@ pub struct EscrowCreate<'a> {
     #[serde(default = "TransactionType::escrow_create")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -50,11 +51,11 @@ pub struct EscrowCreate<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -66,7 +67,7 @@ pub struct EscrowCreate<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -81,11 +82,11 @@ pub struct EscrowCreate<'a> {
     /// See EscrowCreate fields:
     /// `<https://xrpl.org/escrowcreate.html#escrowcreate-flags>`
     pub amount: XRPAmount<'a>,
-    pub destination: &'a str,
+    pub destination: Cow<'a, str>,
     pub destination_tag: Option<u32>,
     pub cancel_after: Option<u32>,
     pub finish_after: Option<u32>,
-    pub condition: Option<&'a str>,
+    pub condition: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for EscrowCreate<'a> {
@@ -134,11 +135,11 @@ impl<'a> EscrowCreateError for EscrowCreate<'a> {
         if let (Some(finish_after), Some(cancel_after)) = (self.finish_after, self.cancel_after) {
             if finish_after >= cancel_after {
                 Err(XRPLEscrowCreateException::ValueBelowValue {
-                    field1: "cancel_after",
-                    field2: "finish_after",
+                    field1: "cancel_after".into(),
+                    field2: "finish_after".into(),
                     field1_val: cancel_after,
                     field2_val: finish_after,
-                    resource: "",
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -151,23 +152,23 @@ impl<'a> EscrowCreateError for EscrowCreate<'a> {
 
 impl<'a> EscrowCreate<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         amount: XRPAmount<'a>,
-        destination: &'a str,
+        destination: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         destination_tag: Option<u32>,
         cancel_after: Option<u32>,
         finish_after: Option<u32>,
-        condition: Option<&'a str>,
+        condition: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::EscrowCreate,
@@ -211,7 +212,7 @@ mod test_escrow_create_errors {
     fn test_cancel_after_error() {
         let escrow_create = EscrowCreate {
             transaction_type: TransactionType::EscrowCreate,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -224,7 +225,7 @@ mod test_escrow_create_errors {
             memos: None,
             signers: None,
             amount: XRPAmount::from("100000000"),
-            destination: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            destination: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             destination_tag: None,
             cancel_after: Some(13298498),
             finish_after: Some(14359039),
@@ -245,9 +246,9 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = EscrowCreate::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             XRPAmount::from("10000"),
-            "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+            "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW".into(),
             None,
             None,
             None,
@@ -261,7 +262,7 @@ mod test_serde {
             Some(23480),
             Some(533257958),
             Some(533171558),
-            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"),
+            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into()),
         );
         let default_json = r#"{"TransactionType":"EscrowCreate","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","SourceTag":11747,"Amount":"10000","Destination":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","DestinationTag":23480,"CancelAfter":533257958,"FinishAfter":533171558,"Condition":"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"}"#;
 
@@ -274,9 +275,9 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = EscrowCreate::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             XRPAmount::from("10000"),
-            "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+            "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW".into(),
             None,
             None,
             None,
@@ -290,7 +291,7 @@ mod test_serde {
             Some(23480),
             Some(533257958),
             Some(533171558),
-            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"),
+            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into()),
         );
         let default_json = r#"{"TransactionType":"EscrowCreate","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Amount":"10000","Destination":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","CancelAfter":533257958,"FinishAfter":533171558,"Condition":"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100","DestinationTag":23480,"SourceTag":11747}"#;
 

--- a/src/models/transactions/escrow_create.rs
+++ b/src/models/transactions/escrow_create.rs
@@ -1,6 +1,6 @@
 use crate::Err;
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -262,7 +262,10 @@ mod test_serde {
             Some(23480),
             Some(533257958),
             Some(533171558),
-            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into()),
+            Some(
+                "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"
+                    .into(),
+            ),
         );
         let default_json = r#"{"TransactionType":"EscrowCreate","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","SourceTag":11747,"Amount":"10000","Destination":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","DestinationTag":23480,"CancelAfter":533257958,"FinishAfter":533171558,"Condition":"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"}"#;
 
@@ -291,7 +294,10 @@ mod test_serde {
             Some(23480),
             Some(533257958),
             Some(533171558),
-            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into()),
+            Some(
+                "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"
+                    .into(),
+            ),
         );
         let default_json = r#"{"TransactionType":"EscrowCreate","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Amount":"10000","Destination":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","CancelAfter":533257958,"FinishAfter":533171558,"Condition":"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100","DestinationTag":23480,"SourceTag":11747}"#;
 

--- a/src/models/transactions/escrow_create.rs
+++ b/src/models/transactions/escrow_create.rs
@@ -70,7 +70,7 @@ pub struct EscrowCreate<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -162,7 +162,7 @@ impl<'a> EscrowCreate<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         destination_tag: Option<u32>,
         cancel_after: Option<u32>,

--- a/src/models/transactions/escrow_finish.rs
+++ b/src/models/transactions/escrow_finish.rs
@@ -70,7 +70,7 @@ pub struct EscrowFinish<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -154,7 +154,7 @@ impl<'a> EscrowFinish<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         condition: Option<&'a str>,
         fulfillment: Option<&'a str>,

--- a/src/models/transactions/escrow_finish.rs
+++ b/src/models/transactions/escrow_finish.rs
@@ -1,4 +1,5 @@
 use crate::Err;
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -30,7 +31,7 @@ pub struct EscrowFinish<'a> {
     #[serde(default = "TransactionType::escrow_finish")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -50,11 +51,11 @@ pub struct EscrowFinish<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -66,7 +67,7 @@ pub struct EscrowFinish<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -80,10 +81,10 @@ pub struct EscrowFinish<'a> {
     ///
     /// See EscrowFinish fields:
     /// `<https://xrpl.org/escrowfinish.html#escrowfinish-fields>`
-    pub owner: &'a str,
+    pub owner: Cow<'a, str>,
     pub offer_sequence: u32,
-    pub condition: Option<&'a str>,
-    pub fulfillment: Option<&'a str>,
+    pub condition: Option<Cow<'a, str>>,
+    pub fulfillment: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for EscrowFinish<'a> {
@@ -131,9 +132,9 @@ impl<'a> EscrowFinishError for EscrowFinish<'a> {
             || (self.condition.is_none() && self.condition.is_some())
         {
             Err(XRPLEscrowFinishException::FieldRequiresField {
-                field1: "condition",
-                field2: "fulfillment",
-                resource: "",
+                field1: "condition".into(),
+                field2: "fulfillment".into(),
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -143,21 +144,21 @@ impl<'a> EscrowFinishError for EscrowFinish<'a> {
 
 impl<'a> EscrowFinish<'a> {
     pub fn new(
-        account: &'a str,
-        owner: &'a str,
+        account: Cow<'a, str>,
+        owner: Cow<'a, str>,
         offer_sequence: u32,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
-        condition: Option<&'a str>,
-        fulfillment: Option<&'a str>,
+        condition: Option<Cow<'a, str>>,
+        fulfillment: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::EscrowFinish,
@@ -197,7 +198,7 @@ mod test_escrow_finish_errors {
     fn test_condition_and_fulfillment_error() {
         let escrow_finish = EscrowFinish {
             transaction_type: TransactionType::EscrowCancel,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -209,10 +210,10 @@ mod test_escrow_finish_errors {
             flags: None,
             memos: None,
             signers: None,
-            owner: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            owner: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             offer_sequence: 10,
             condition: Some(
-                "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100",
+                "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into(),
             ),
             fulfillment: None,
         };
@@ -231,8 +232,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = EscrowFinish::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             7,
             None,
             None,
@@ -244,8 +245,8 @@ mod test_serde {
             None,
             None,
             None,
-            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"),
-            Some("A0028000"),
+            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into()),
+            Some("A0028000".into()),
         );
         let default_json = r#"{"TransactionType":"EscrowFinish","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Owner":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","OfferSequence":7,"Condition":"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100","Fulfillment":"A0028000"}"#;
 
@@ -258,8 +259,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = EscrowFinish::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             7,
             None,
             None,
@@ -271,8 +272,8 @@ mod test_serde {
             None,
             None,
             None,
-            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"),
-            Some("A0028000"),
+            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into()),
+            Some("A0028000".into()),
         );
         let default_json = r#"{"TransactionType":"EscrowFinish","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Owner":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","OfferSequence":7,"Condition":"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100","Fulfillment":"A0028000"}"#;
 

--- a/src/models/transactions/escrow_finish.rs
+++ b/src/models/transactions/escrow_finish.rs
@@ -213,7 +213,8 @@ mod test_escrow_finish_errors {
             owner: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             offer_sequence: 10,
             condition: Some(
-                "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into(),
+                "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"
+                    .into(),
             ),
             fulfillment: None,
         };
@@ -245,7 +246,10 @@ mod test_serde {
             None,
             None,
             None,
-            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into()),
+            Some(
+                "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"
+                    .into(),
+            ),
             Some("A0028000".into()),
         );
         let default_json = r#"{"TransactionType":"EscrowFinish","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Owner":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","OfferSequence":7,"Condition":"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100","Fulfillment":"A0028000"}"#;
@@ -272,7 +276,10 @@ mod test_serde {
             None,
             None,
             None,
-            Some("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100".into()),
+            Some(
+                "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"
+                    .into(),
+            ),
             Some("A0028000".into()),
         );
         let default_json = r#"{"TransactionType":"EscrowFinish","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Owner":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","OfferSequence":7,"Condition":"A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100","Fulfillment":"A0028000"}"#;

--- a/src/models/transactions/exceptions.rs
+++ b/src/models/transactions/exceptions.rs
@@ -1,7 +1,7 @@
 use crate::models::transactions::{AccountSetFlag, PaymentFlag};
+use alloc::borrow::Cow;
 use strum_macros::Display;
 use thiserror_no_std::Error;
-use alloc::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum XRPLTransactionException<'a> {
@@ -153,7 +153,10 @@ pub enum XRPLNFTokenAcceptOfferException<'a> {
     },
     /// The value can not be zero.
     #[error("The value of the field `{field:?}` is not allowed to be zero. For more information see: {resource:?}")]
-    ValueZero { field: Cow<'a, str>, resource: Cow<'a, str> },
+    ValueZero {
+        field: Cow<'a, str>,
+        resource: Cow<'a, str>,
+    },
 }
 
 #[cfg(feature = "std")]
@@ -177,7 +180,10 @@ impl<'a> alloc::error::Error for XRPLNFTokenCancelOfferException<'a> {}
 pub enum XRPLNFTokenCreateOfferException<'a> {
     /// The value can not be zero.
     #[error("The value of the field `{field:?}` is not allowed to be zero. For more information see: {resource:?}")]
-    ValueZero { field: Cow<'a, str>, resource: Cow<'a, str> },
+    ValueZero {
+        field: Cow<'a, str>,
+        resource: Cow<'a, str>,
+    },
     /// A fields value is not allowed to be the same as another fields value.
     #[error("The value of the field `{field1:?}` is not allowed to be the same as the value of the field `{field2:?}`. For more information see: {resource:?}")]
     ValueEqualsValue {

--- a/src/models/transactions/exceptions.rs
+++ b/src/models/transactions/exceptions.rs
@@ -1,6 +1,7 @@
 use crate::models::transactions::{AccountSetFlag, PaymentFlag};
 use strum_macros::Display;
 use thiserror_no_std::Error;
+use alloc::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum XRPLTransactionException<'a> {
@@ -274,53 +275,53 @@ pub enum XRPLSignerListSetException<'a> {
     /// A field was defined that another field definition would delete.
     #[error("The value of the field `{field1:?}` can not be defined with the field `{field2:?}` because it would cause the deletion of `{field1:?}`. For more information see: {resource:?}")]
     ValueCausesValueDeletion {
-        field1: &'a str,
-        field2: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// A field is expected to have a certain value to be deleted.
     #[error("The field `{field:?}` has the wrong value to be deleted (expected {expected:?}, found {found:?}). For more information see: {resource:?}")]
     InvalidValueForValueDeletion {
-        field: &'a str,
+        field: Cow<'a, str>,
         expected: u32,
         found: u32,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// A collection has too few items in it.
     #[error("The value of the field `{field:?}` has too few items in it (min {min:?}, found {found:?}). For more information see: {resource:?}")]
     CollectionTooFewItems {
-        field: &'a str,
+        field: Cow<'a, str>,
         min: usize,
         found: usize,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// A collection has too many items in it.
     #[error("The value of the field `{field:?}` has too many items in it (max {max:?}, found {found:?}). For more information see: {resource:?}")]
     CollectionTooManyItems {
-        field: &'a str,
+        field: Cow<'a, str>,
         max: usize,
         found: usize,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// A collection is not allowed to have duplicates in it.
     #[error("The value of the field `{field:?}` has a duplicate in it (found {found:?}). For more information see: {resource:?}")]
     CollectionItemDuplicate {
-        field: &'a str,
-        found: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        found: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// A collection contains an invalid value.
     #[error("The field `{field:?}` contains an invalid value (found {found:?}). For more information see: {resource:?}")]
     CollectionInvalidItem {
-        field: &'a str,
-        found: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        found: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     #[error("The field `signer_quorum` must be below or equal to the sum of `signer_weight` in `signer_entries`. For more information see: {resource:?}")]
     SignerQuorumExceedsSignerWeight {
         max: u32,
         found: u32,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
 }
 

--- a/src/models/transactions/exceptions.rs
+++ b/src/models/transactions/exceptions.rs
@@ -26,61 +26,61 @@ pub enum XRPLAccountSetException<'a> {
     /// A fields value exceeds its maximum value.
     #[error("The value of the field `{field:?}` is defined above its maximum (max {max:?}, found {found:?}). For more information see: {resource:?}")]
     ValueTooHigh {
-        field: &'a str,
+        field: Cow<'a, str>,
         max: u32,
         found: u32,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// A fields value exceeds its minimum value.
     #[error("The value of the field `{field:?}` is defined below its minimum (min {min:?}, found {found:?}). For more information see: {resource:?}")]
     ValueTooLow {
-        field: &'a str,
+        field: Cow<'a, str>,
         min: u32,
         found: u32,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// A fields value exceeds its maximum character length.
     #[error("The value of the field `{field:?}` exceeds its maximum length of characters (max {max:?}, found {found:?}). For more information see: {resource:?}")]
     ValueTooLong {
-        field: &'a str,
+        field: Cow<'a, str>,
         max: usize,
         found: usize,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// A fields value doesn't match its required format.
     #[error("The value of the field `{field:?}` does not have the correct format (expected {format:?}, found {found:?}). For more information see: {resource:?}")]
     InvalidValueFormat {
-        field: &'a str,
-        format: &'a str,
-        found: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        format: Cow<'a, str>,
+        found: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// A field can only be defined if a transaction flag is set.
     #[error("For the field `{field:?}` to be defined it is required to set the flag `{flag:?}`. For more information see: {resource:?}")]
     FieldRequiresFlag {
-        field: &'a str,
+        field: Cow<'a, str>,
         flag: AccountSetFlag,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// An account set flag can only be set if a field is defined.
     #[error("For the flag `{flag:?}` to be set it is required to define the field `{field:?}`. For more information see: {resource:?}")]
     FlagRequiresField {
         flag: AccountSetFlag,
-        field: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// Am account set flag can not be set and unset at the same time.
     #[error("A flag cannot be set and unset at the same time (found {found:?}). For more information see: {resource:?}")]
     SetAndUnsetSameFlag {
         found: AccountSetFlag,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// A field was defined and an account set flag that is required for that field was unset.
     #[error("The field `{field:?}` cannot be defined if its required flag `{flag:?}` is being unset. For more information see: {resource:?}")]
     SetFieldWhenUnsetRequiredFlag {
-        field: &'a str,
+        field: Cow<'a, str>,
         flag: AccountSetFlag,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -92,9 +92,9 @@ pub enum XRPLCheckCashException<'a> {
     /// A field cannot be defined with other fields.
     #[error("The field `{field1:?}` can not be defined with `{field2:?}`. Define exactly one of them. For more information see: {resource:?}")]
     DefineExactlyOneOf {
-        field1: &'a str,
-        field2: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -103,9 +103,9 @@ pub enum XRPLDepositPreauthException<'a> {
     /// A field cannot be defined with other fields.
     #[error("The field `{field1:?}` can not be defined with `{field2:?}`. Define exactly one of them. For more information see: {resource:?}")]
     DefineExactlyOneOf {
-        field1: &'a str,
-        field2: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -117,11 +117,11 @@ pub enum XRPLEscrowCreateException<'a> {
     /// A fields value cannot be below another fields value.
     #[error("The value of the field `{field1:?}` is not allowed to be below the value of the field `{field2:?}` (max {field2_val:?}, found {field1_val:?}). For more information see: {resource:?}")]
     ValueBelowValue {
-        field1: &'a str,
-        field2: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
         field1_val: u32,
         field2_val: u32,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -133,9 +133,9 @@ pub enum XRPLEscrowFinishException<'a> {
     /// For a field to be defined it also needs another field to be defined.
     #[error("For the field `{field1:?}` to be defined it is required to also define the field `{field2:?}`. For more information see: {resource:?}")]
     FieldRequiresField {
-        field1: &'a str,
-        field2: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -147,13 +147,13 @@ pub enum XRPLNFTokenAcceptOfferException<'a> {
     /// Define at least one of the fields.
     #[error("Define at least one of the fields `{field1:?}` and `{field2:?}`. For more information see: {resource:?}")]
     DefineOneOf {
-        field1: &'a str,
-        field2: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// The value can not be zero.
     #[error("The value of the field `{field:?}` is not allowed to be zero. For more information see: {resource:?}")]
-    ValueZero { field: &'a str, resource: &'a str },
+    ValueZero { field: Cow<'a, str>, resource: Cow<'a, str> },
 }
 
 #[cfg(feature = "std")]
@@ -164,9 +164,9 @@ pub enum XRPLNFTokenCancelOfferException<'a> {
     /// A collection was defined to be empty.
     #[error("The value of the field `{field:?}` is not allowed to be empty (type `{r#type:?}`). If the field is optional, define it to be `None`. For more information see: {resource:?}")]
     CollectionEmpty {
-        field: &'a str,
-        r#type: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        r#type: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -177,27 +177,27 @@ impl<'a> alloc::error::Error for XRPLNFTokenCancelOfferException<'a> {}
 pub enum XRPLNFTokenCreateOfferException<'a> {
     /// The value can not be zero.
     #[error("The value of the field `{field:?}` is not allowed to be zero. For more information see: {resource:?}")]
-    ValueZero { field: &'a str, resource: &'a str },
+    ValueZero { field: Cow<'a, str>, resource: Cow<'a, str> },
     /// A fields value is not allowed to be the same as another fields value.
     #[error("The value of the field `{field1:?}` is not allowed to be the same as the value of the field `{field2:?}`. For more information see: {resource:?}")]
     ValueEqualsValue {
-        field1: &'a str,
-        field2: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// An optional value must be defined in a certain context.
     #[error("The optional field `{field:?}` is required to be defined for {context:?}. For more information see: {resource:?}")]
     OptionRequired {
-        field: &'a str,
-        context: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        context: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// An optional value is not allowed to be defined in a certain context.
     #[error("The optional field `{field:?}` is not allowed to be defined for {context:?}. For more information see: {resource:?}")]
     IllegalOption {
-        field: &'a str,
-        context: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        context: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -209,25 +209,25 @@ pub enum XRPLNFTokenMintException<'a> {
     /// A fields value is not allowed to be the same as another fields value.
     #[error("The value of the field `{field1:?}` is not allowed to be the same as the value of the field `{field2:?}`. For more information see: {resource:?}")]
     ValueEqualsValue {
-        field1: &'a str,
-        field2: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// A fields value exceeds its maximum value.
     #[error("The field `{field:?}` exceeds its maximum value (max {max:?}, found {found:?}). For more information see: {resource:?}")]
     ValueTooHigh {
-        field: &'a str,
+        field: Cow<'a, str>,
         max: u32,
         found: u32,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
     /// A fields value exceeds its maximum character length.
     #[error("The value of the field `{field:?}` exceeds its maximum length of characters (max {max:?}, found {found:?}). For more information see: {resource:?}")]
     ValueTooLong {
-        field: &'a str,
+        field: Cow<'a, str>,
         max: usize,
         found: usize,
-        resource: &'a str,
+        resource: Cow<'a, str>,
     },
 }
 
@@ -239,31 +239,31 @@ pub enum XRPLPaymentException<'a> {
     /// An optional value must be defined in a certain context.
     #[error("The optional field `{field:?}` is required to be defined for {context:?}. For more information see: {resource:?}")]
     OptionRequired {
-        field: &'a str,
-        context: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        context: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// An optional value is not allowed to be defined in a certain context.
     #[error("The optional field `{field:?}` is not allowed to be defined for {context:?}.For more information see: {resource:?}")]
     IllegalOption {
-        field: &'a str,
-        context: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        context: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// A fields value is not allowed to be the same as another fields value, in a certain context.
     #[error("The value of the field `{field1:?}` is not allowed to be the same as the value of the field `{field2:?}`, for {context:?}. For more information see: {resource:?}")]
     ValueEqualsValueInContext {
-        field1: &'a str,
-        field2: &'a str,
-        context: &'a str,
-        resource: &'a str,
+        field1: Cow<'a, str>,
+        field2: Cow<'a, str>,
+        context: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
     /// An account set flag can only be set if a field is defined.
     #[error("For the flag `{flag:?}` to be set it is required to define the field `{field:?}`. For more information see: {resource:?}")]
     FlagRequiresField {
         flag: PaymentFlag,
-        field: &'a str,
-        resource: &'a str,
+        field: Cow<'a, str>,
+        resource: Cow<'a, str>,
     },
 }
 

--- a/src/models/transactions/mod.rs
+++ b/src/models/transactions/mod.rs
@@ -53,6 +53,7 @@ pub use ticket_create::*;
 pub use trust_set::*;
 
 use crate::serde_with_tag;
+use alloc::borrow::Cow;
 use alloc::string::String;
 use derive_new::new;
 use serde::ser::SerializeMap;
@@ -207,9 +208,9 @@ pub struct Memo {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, new)]
 #[serde(rename_all = "PascalCase")]
 pub struct Signer<'a> {
-    account: &'a str,
-    txn_signature: &'a str,
-    signing_pub_key: &'a str,
+    account: Cow<'a, str>,
+    txn_signature: Cow<'a, str>,
+    signing_pub_key: Cow<'a, str>,
 }
 
 /// Standard functions for transactions.

--- a/src/models/transactions/mod.rs
+++ b/src/models/transactions/mod.rs
@@ -53,6 +53,7 @@ pub use ticket_create::*;
 pub use trust_set::*;
 
 use crate::serde_with_tag;
+use alloc::string::String;
 use derive_new::new;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
@@ -190,10 +191,10 @@ serde_with_tag! {
 /// `<https://xrpl.org/transaction-common-fields.html#memos-field>`
 // `#[derive(Serialize)]` is defined in the macro
 #[derive(Debug, PartialEq, Eq, Default, Clone, new)]
-pub struct Memo<'a> {
-    pub memo_data: Option<&'a str>,
-    pub memo_format: Option<&'a str>,
-    pub memo_type: Option<&'a str>,
+pub struct Memo {
+    pub memo_data: Option<String>,
+    pub memo_format: Option<String>,
+    pub memo_type: Option<String>,
 }
 }
 

--- a/src/models/transactions/nftoken_accept_offer.rs
+++ b/src/models/transactions/nftoken_accept_offer.rs
@@ -1,6 +1,6 @@
 use crate::Err;
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use anyhow::Result;
 use core::convert::TryInto;
 use rust_decimal::Decimal;
@@ -284,8 +284,8 @@ mod test_nftoken_accept_offer_error {
 
 #[cfg(test)]
 mod test_serde {
-    use alloc::vec;
     use alloc::string::ToString;
+    use alloc::vec;
 
     use super::*;
 
@@ -302,7 +302,10 @@ mod test_serde {
             None,
             None,
             Some(vec![Memo::new(
-                Some("61356534373538372D633134322D346663382D616466362D393666383562356435386437".to_string()),
+                Some(
+                    "61356534373538372D633134322D346663382D616466362D393666383562356435386437"
+                        .to_string(),
+                ),
                 None,
                 None,
             )]),
@@ -332,7 +335,10 @@ mod test_serde {
             None,
             None,
             Some(vec![Memo::new(
-                Some("61356534373538372D633134322D346663382D616466362D393666383562356435386437".to_string()),
+                Some(
+                    "61356534373538372D633134322D346663382D616466362D393666383562356435386437"
+                        .to_string(),
+                ),
                 None,
                 None,
             )]),

--- a/src/models/transactions/nftoken_accept_offer.rs
+++ b/src/models/transactions/nftoken_accept_offer.rs
@@ -140,9 +140,9 @@ impl<'a> NFTokenAcceptOfferError for NFTokenAcceptOffer<'a> {
             && self.nftoken_buy_offer.is_none()
         {
             Err(XRPLNFTokenAcceptOfferException::DefineOneOf {
-                field1: "nftoken_sell_offer",
-                field2: "nftoken_buy_offer",
-                resource: "",
+                field1: "nftoken_sell_offer".into(),
+                field2: "nftoken_buy_offer".into(),
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -156,8 +156,8 @@ impl<'a> NFTokenAcceptOfferError for NFTokenAcceptOffer<'a> {
                 Ok(nftoken_broker_fee_dec) => {
                     if nftoken_broker_fee_dec.is_zero() {
                         Err!(XRPLNFTokenAcceptOfferException::ValueZero {
-                            field: "nftoken_broker_fee",
-                            resource: "",
+                            field: "nftoken_broker_fee".into(),
+                            resource: "".into(),
                         })
                     } else {
                         Ok(())
@@ -230,7 +230,7 @@ mod test_nftoken_accept_offer_error {
     fn test_brokered_mode_error() {
         let nftoken_accept_offer = NFTokenAcceptOffer {
             transaction_type: TransactionType::NFTokenAcceptOffer,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -257,7 +257,7 @@ mod test_nftoken_accept_offer_error {
     fn test_broker_fee_error() {
         let nftoken_accept_offer = NFTokenAcceptOffer {
             transaction_type: TransactionType::NFTokenAcceptOffer,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -269,7 +269,7 @@ mod test_nftoken_accept_offer_error {
             flags: None,
             memos: None,
             signers: None,
-            nftoken_sell_offer: Some(""),
+            nftoken_sell_offer: Some("".into()),
             nftoken_buy_offer: None,
             nftoken_broker_fee: Some(Amount::XRPAmount(XRPAmount::from("0"))),
         };
@@ -291,7 +291,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = NFTokenAcceptOffer::new(
-            "r9spUPhPBfB6kQeF6vPhwmtFwRhBh2JUCG",
+            "r9spUPhPBfB6kQeF6vPhwmtFwRhBh2JUCG".into(),
             Some("12".into()),
             Some(68549302),
             Some(75447550),
@@ -306,7 +306,7 @@ mod test_serde {
                 None,
             )]),
             None,
-            Some("68CD1F6F906494EA08C9CB5CAFA64DFA90D4E834B7151899B73231DE5A0C3B77"),
+            Some("68CD1F6F906494EA08C9CB5CAFA64DFA90D4E834B7151899B73231DE5A0C3B77".into()),
             None,
             None,
         );
@@ -321,7 +321,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = NFTokenAcceptOffer::new(
-            "r9spUPhPBfB6kQeF6vPhwmtFwRhBh2JUCG",
+            "r9spUPhPBfB6kQeF6vPhwmtFwRhBh2JUCG".into(),
             Some("12".into()),
             Some(68549302),
             Some(75447550),
@@ -336,7 +336,7 @@ mod test_serde {
                 None,
             )]),
             None,
-            Some("68CD1F6F906494EA08C9CB5CAFA64DFA90D4E834B7151899B73231DE5A0C3B77"),
+            Some("68CD1F6F906494EA08C9CB5CAFA64DFA90D4E834B7151899B73231DE5A0C3B77".into()),
             None,
             None,
         );

--- a/src/models/transactions/nftoken_accept_offer.rs
+++ b/src/models/transactions/nftoken_accept_offer.rs
@@ -1,5 +1,6 @@
 use crate::Err;
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use anyhow::Result;
 use core::convert::TryInto;
 use rust_decimal::Decimal;
@@ -34,7 +35,7 @@ pub struct NFTokenAcceptOffer<'a> {
     #[serde(default = "TransactionType::nftoken_accept_offer")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -54,11 +55,11 @@ pub struct NFTokenAcceptOffer<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -70,7 +71,7 @@ pub struct NFTokenAcceptOffer<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -85,9 +86,9 @@ pub struct NFTokenAcceptOffer<'a> {
     /// See NFTokenAcceptOffer fields:
     /// `<https://xrpl.org/nftokenacceptoffer.html#nftokenacceptoffer-fields>`
     #[serde(rename = "NFTokenSellOffer")]
-    pub nftoken_sell_offer: Option<&'a str>,
+    pub nftoken_sell_offer: Option<Cow<'a, str>>,
     #[serde(rename = "NFTokenBuyOffer")]
-    pub nftoken_buy_offer: Option<&'a str>,
+    pub nftoken_buy_offer: Option<Cow<'a, str>>,
     #[serde(rename = "NFTokenBrokerFee")]
     pub nftoken_broker_fee: Option<Amount<'a>>,
 }
@@ -173,19 +174,19 @@ impl<'a> NFTokenAcceptOfferError for NFTokenAcceptOffer<'a> {
 
 impl<'a> NFTokenAcceptOffer<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
-        nftoken_sell_offer: Option<&'a str>,
-        nftoken_buy_offer: Option<&'a str>,
+        nftoken_sell_offer: Option<Cow<'a, str>>,
+        nftoken_buy_offer: Option<Cow<'a, str>>,
         nftoken_broker_fee: Option<Amount<'a>>,
     ) -> Self {
         Self {

--- a/src/models/transactions/nftoken_accept_offer.rs
+++ b/src/models/transactions/nftoken_accept_offer.rs
@@ -74,7 +74,7 @@ pub struct NFTokenAcceptOffer<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -182,7 +182,7 @@ impl<'a> NFTokenAcceptOffer<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         nftoken_sell_offer: Option<&'a str>,
         nftoken_buy_offer: Option<&'a str>,
@@ -284,6 +284,7 @@ mod test_nftoken_accept_offer_error {
 #[cfg(test)]
 mod test_serde {
     use alloc::vec;
+    use alloc::string::ToString;
 
     use super::*;
 
@@ -300,7 +301,7 @@ mod test_serde {
             None,
             None,
             Some(vec![Memo::new(
-                Some("61356534373538372D633134322D346663382D616466362D393666383562356435386437"),
+                Some("61356534373538372D633134322D346663382D616466362D393666383562356435386437".to_string()),
                 None,
                 None,
             )]),
@@ -330,7 +331,7 @@ mod test_serde {
             None,
             None,
             Some(vec![Memo::new(
-                Some("61356534373538372D633134322D346663382D616466362D393666383562356435386437"),
+                Some("61356534373538372D633134322D346663382D616466362D393666383562356435386437".to_string()),
                 None,
                 None,
             )]),

--- a/src/models/transactions/nftoken_burn.rs
+++ b/src/models/transactions/nftoken_burn.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -28,7 +29,7 @@ pub struct NFTokenBurn<'a> {
     #[serde(default = "TransactionType::nftoken_burn")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -48,11 +49,11 @@ pub struct NFTokenBurn<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -64,7 +65,7 @@ pub struct NFTokenBurn<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -79,8 +80,8 @@ pub struct NFTokenBurn<'a> {
     /// See NFTokenBurn fields:
     /// `<https://xrpl.org/nftokenburn.html#nftokenburn-fields>`
     #[serde(rename = "NFTokenID")]
-    pub nftoken_id: &'a str,
-    pub owner: Option<&'a str>,
+    pub nftoken_id: Cow<'a, str>,
+    pub owner: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for NFTokenBurn<'a> {
@@ -115,19 +116,19 @@ impl<'a> Transaction for NFTokenBurn<'a> {
 
 impl<'a> NFTokenBurn<'a> {
     pub fn new(
-        account: &'a str,
-        nftoken_id: &'a str,
+        account: Cow<'a, str>,
+        nftoken_id: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
-        owner: Option<&'a str>,
+        owner: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::NFTokenBurn,
@@ -156,8 +157,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = NFTokenBurn::new(
-            "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
-            "000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65",
+            "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2".into(),
+            "000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65".into(),
             Some("10".into()),
             None,
             None,
@@ -168,7 +169,7 @@ mod test_serde {
             None,
             None,
             None,
-            Some("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"),
+            Some("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B".into()),
         );
         let default_json = r#"{"TransactionType":"NFTokenBurn","Account":"rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2","Fee":"10","NFTokenID":"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65","Owner":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"}"#;
 
@@ -181,8 +182,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = NFTokenBurn::new(
-            "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
-            "000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65",
+            "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2".into(),
+            "000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65".into(),
             Some("10".into()),
             None,
             None,
@@ -193,7 +194,7 @@ mod test_serde {
             None,
             None,
             None,
-            Some("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"),
+            Some("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B".into()),
         );
         let default_json = r#"{"TransactionType":"NFTokenBurn","Account":"rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2","Owner":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","Fee":"10","NFTokenID":"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65"}"#;
 

--- a/src/models/transactions/nftoken_burn.rs
+++ b/src/models/transactions/nftoken_burn.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/nftoken_burn.rs
+++ b/src/models/transactions/nftoken_burn.rs
@@ -68,7 +68,7 @@ pub struct NFTokenBurn<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -125,7 +125,7 @@ impl<'a> NFTokenBurn<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         owner: Option<&'a str>,
     ) -> Self {

--- a/src/models/transactions/nftoken_cancel_offer.rs
+++ b/src/models/transactions/nftoken_cancel_offer.rs
@@ -84,7 +84,7 @@ pub struct NFTokenCancelOffer<'a> {
     /// Lifetime issue
     #[serde(borrow)]
     #[serde(rename = "NFTokenOffers")]
-    pub nftoken_offers: Vec<&'a str>,
+    pub nftoken_offers: Vec<Cow<'a, str>>,
 }
 
 impl<'a> Default for NFTokenCancelOffer<'a> {
@@ -140,7 +140,7 @@ impl<'a> NFTokenCancelOfferError for NFTokenCancelOffer<'a> {
 impl<'a> NFTokenCancelOffer<'a> {
     pub fn new(
         account: Cow<'a, str>,
-        nftoken_offers: Vec<&'a str>,
+        nftoken_offers: Vec<Cow<'a, str>>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
@@ -220,7 +220,7 @@ mod test_serde {
     fn test_serialize() {
         let default_txn = NFTokenCancelOffer::new(
             "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
-            vec!["9C92E061381C1EF37A8CDE0E8FC35188BFC30B1883825042A64309AC09F4C36D"],
+            vec!["9C92E061381C1EF37A8CDE0E8FC35188BFC30B1883825042A64309AC09F4C36D".into()],
             None,
             None,
             None,
@@ -244,7 +244,7 @@ mod test_serde {
     fn test_deserialize() {
         let default_txn = NFTokenCancelOffer::new(
             "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
-            vec!["9C92E061381C1EF37A8CDE0E8FC35188BFC30B1883825042A64309AC09F4C36D"],
+            vec!["9C92E061381C1EF37A8CDE0E8FC35188BFC30B1883825042A64309AC09F4C36D".into()],
             None,
             None,
             None,

--- a/src/models/transactions/nftoken_cancel_offer.rs
+++ b/src/models/transactions/nftoken_cancel_offer.rs
@@ -70,7 +70,7 @@ pub struct NFTokenCancelOffer<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -148,7 +148,7 @@ impl<'a> NFTokenCancelOffer<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
         Self {

--- a/src/models/transactions/nftoken_cancel_offer.rs
+++ b/src/models/transactions/nftoken_cancel_offer.rs
@@ -1,7 +1,7 @@
 use crate::Err;
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use anyhow::Result;
-use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/nftoken_cancel_offer.rs
+++ b/src/models/transactions/nftoken_cancel_offer.rs
@@ -1,6 +1,7 @@
 use crate::Err;
 use alloc::vec::Vec;
 use anyhow::Result;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -30,7 +31,7 @@ pub struct NFTokenCancelOffer<'a> {
     #[serde(default = "TransactionType::nftoken_cancel_offer")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -50,11 +51,11 @@ pub struct NFTokenCancelOffer<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -66,7 +67,7 @@ pub struct NFTokenCancelOffer<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -126,9 +127,9 @@ impl<'a> NFTokenCancelOfferError for NFTokenCancelOffer<'a> {
     fn _get_nftoken_offers_error(&self) -> Result<(), XRPLNFTokenCancelOfferException> {
         if self.nftoken_offers.is_empty() {
             Err(XRPLNFTokenCancelOfferException::CollectionEmpty {
-                field: "nftoken_offers",
-                r#type: stringify!(Vec),
-                resource: "",
+                field: "nftoken_offers".into(),
+                r#type: stringify!(Vec).into(),
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -138,16 +139,16 @@ impl<'a> NFTokenCancelOfferError for NFTokenCancelOffer<'a> {
 
 impl<'a> NFTokenCancelOffer<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         nftoken_offers: Vec<&'a str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
@@ -187,7 +188,7 @@ mod test_nftoken_cancel_offer_error {
     fn test_nftoken_offer_error() {
         let nftoken_cancel_offer = NFTokenCancelOffer {
             transaction_type: TransactionType::NFTokenCancelOffer,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -218,7 +219,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = NFTokenCancelOffer::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
             vec!["9C92E061381C1EF37A8CDE0E8FC35188BFC30B1883825042A64309AC09F4C36D"],
             None,
             None,
@@ -242,7 +243,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = NFTokenCancelOffer::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
             vec!["9C92E061381C1EF37A8CDE0E8FC35188BFC30B1883825042A64309AC09F4C36D"],
             None,
             None,

--- a/src/models/transactions/nftoken_create_offer.rs
+++ b/src/models/transactions/nftoken_create_offer.rs
@@ -1,8 +1,8 @@
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use anyhow::Result;
 use core::convert::TryInto;
 use rust_decimal::Decimal;
-use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;

--- a/src/models/transactions/nftoken_create_offer.rs
+++ b/src/models/transactions/nftoken_create_offer.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use anyhow::Result;
 use core::convert::TryInto;
 use rust_decimal::Decimal;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
@@ -54,7 +55,7 @@ pub struct NFTokenCreateOffer<'a> {
     #[serde(default = "TransactionType::nftoken_create_offer")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -74,11 +75,11 @@ pub struct NFTokenCreateOffer<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -90,7 +91,7 @@ pub struct NFTokenCreateOffer<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     #[serde(default)]
     #[serde(with = "txn_flags")]
@@ -107,11 +108,11 @@ pub struct NFTokenCreateOffer<'a> {
     /// See NFTokenCreateOffer fields:
     /// `<https://xrpl.org/nftokencreateoffer.html#nftokencreateoffer-fields>`
     #[serde(rename = "NFTokenID")]
-    pub nftoken_id: &'a str,
+    pub nftoken_id: Cow<'a, str>,
     pub amount: Amount<'a>,
-    pub owner: Option<&'a str>,
+    pub owner: Option<Cow<'a, str>>,
     pub expiration: Option<u32>,
-    pub destination: Option<&'a str>,
+    pub destination: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for NFTokenCreateOffer<'a> {
@@ -190,8 +191,8 @@ impl<'a> NFTokenCreateOfferError for NFTokenCreateOffer<'a> {
                 )) && amount.is_zero()
                 {
                     Err!(XRPLNFTokenCreateOfferException::ValueZero {
-                        field: "amount",
-                        resource: "",
+                        field: "amount".into(),
+                        resource: "".into(),
                     })
                 } else {
                     Ok(())
@@ -204,12 +205,12 @@ impl<'a> NFTokenCreateOfferError for NFTokenCreateOffer<'a> {
     }
 
     fn _get_destination_error(&self) -> Result<(), XRPLNFTokenCreateOfferException> {
-        if let Some(destination) = self.destination {
+        if let Some(destination) = self.destination.clone() {
             if destination == self.account {
                 Err(XRPLNFTokenCreateOfferException::ValueEqualsValue {
-                    field1: "destination",
-                    field2: "account",
-                    resource: "",
+                    field1: "destination".into(),
+                    field2: "account".into(),
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -220,20 +221,20 @@ impl<'a> NFTokenCreateOfferError for NFTokenCreateOffer<'a> {
     }
 
     fn _get_owner_error(&self) -> Result<(), XRPLNFTokenCreateOfferException> {
-        if let Some(owner) = self.owner {
+        if let Some(owner) = self.owner.clone() {
             if self.has_flag(&Flag::NFTokenCreateOffer(
                 NFTokenCreateOfferFlag::TfSellOffer,
             )) {
                 Err(XRPLNFTokenCreateOfferException::IllegalOption {
-                    field: "owner",
-                    context: "NFToken sell offers",
-                    resource: "",
+                    field: "owner".into(),
+                    context: "NFToken sell offers".into(),
+                    resource: "".into(),
                 })
             } else if owner == self.account {
                 Err(XRPLNFTokenCreateOfferException::ValueEqualsValue {
-                    field1: "owner",
-                    field2: "account",
-                    resource: "",
+                    field1: "owner".into(),
+                    field2: "account".into(),
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -242,9 +243,9 @@ impl<'a> NFTokenCreateOfferError for NFTokenCreateOffer<'a> {
             NFTokenCreateOfferFlag::TfSellOffer,
         )) {
             Err(XRPLNFTokenCreateOfferException::OptionRequired {
-                field: "owner",
-                context: "NFToken buy offers",
-                resource: "",
+                field: "owner".into(),
+                context: "NFToken buy offers".into(),
+                resource: "".into(),
             })
         } else {
             Ok(())
@@ -254,23 +255,23 @@ impl<'a> NFTokenCreateOfferError for NFTokenCreateOffer<'a> {
 
 impl<'a> NFTokenCreateOffer<'a> {
     pub fn new(
-        account: &'a str,
-        nftoken_id: &'a str,
+        account: Cow<'a, str>,
+        nftoken_id: Cow<'a, str>,
         amount: Amount<'a>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         flags: Option<Vec<NFTokenCreateOfferFlag>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
-        owner: Option<&'a str>,
+        owner: Option<Cow<'a, str>>,
         expiration: Option<u32>,
-        destination: Option<&'a str>,
+        destination: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::NFTokenCreateOffer,
@@ -317,7 +318,7 @@ mod test_nftoken_create_offer_error {
     fn test_amount_error() {
         let nftoken_create_offer = NFTokenCreateOffer {
             transaction_type: TransactionType::NFTokenCreateOffer,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -329,7 +330,7 @@ mod test_nftoken_create_offer_error {
             flags: None,
             memos: None,
             signers: None,
-            nftoken_id: "",
+            nftoken_id: "".into(),
             amount: Amount::XRPAmount(XRPAmount::from("0")),
             owner: None,
             expiration: None,
@@ -350,7 +351,7 @@ mod test_nftoken_create_offer_error {
     fn test_destination_error() {
         let nftoken_create_offer = NFTokenCreateOffer {
             transaction_type: TransactionType::NFTokenCreateOffer,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -362,11 +363,11 @@ mod test_nftoken_create_offer_error {
             flags: None,
             memos: None,
             signers: None,
-            nftoken_id: "",
+            nftoken_id: "".into(),
             amount: Amount::XRPAmount(XRPAmount::from("1")),
             owner: None,
             expiration: None,
-            destination: Some("rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb"),
+            destination: Some("rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into()),
         };
 
         assert_eq!(
@@ -379,7 +380,7 @@ mod test_nftoken_create_offer_error {
     fn test_owner_error() {
         let mut nftoken_create_offer = NFTokenCreateOffer {
             transaction_type: TransactionType::NFTokenCreateOffer,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -391,9 +392,9 @@ mod test_nftoken_create_offer_error {
             flags: None,
             memos: None,
             signers: None,
-            nftoken_id: "",
+            nftoken_id: "".into(),
             amount: Amount::XRPAmount(XRPAmount::from("1")),
-            owner: Some("rLSn6Z3T8uCxbcd1oxwfGQN1Fdn5CyGujK"),
+            owner: Some("rLSn6Z3T8uCxbcd1oxwfGQN1Fdn5CyGujK".into()),
             expiration: None,
             destination: None,
         };
@@ -413,7 +414,7 @@ mod test_nftoken_create_offer_error {
             "The optional field `owner` is required to be defined for NFToken buy offers. For more information see: "
         );
 
-        nftoken_create_offer.owner = Some("rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb");
+        nftoken_create_offer.owner = Some("rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into());
 
         assert_eq!(
             nftoken_create_offer.validate().unwrap_err().to_string().as_str(),
@@ -432,8 +433,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = NFTokenCreateOffer::new(
-            "rs8jBmmfpwgmrSPgwMsh7CvKRmRt1JTVSX",
-            "000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007",
+            "rs8jBmmfpwgmrSPgwMsh7CvKRmRt1JTVSX".into(),
+            "000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007".into(),
             Amount::XRPAmount(XRPAmount::from("1000000")),
             None,
             None,
@@ -461,8 +462,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = NFTokenCreateOffer::new(
-            "rs8jBmmfpwgmrSPgwMsh7CvKRmRt1JTVSX",
-            "000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007",
+            "rs8jBmmfpwgmrSPgwMsh7CvKRmRt1JTVSX".into(),
+            "000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007".into(),
             Amount::XRPAmount(XRPAmount::from("1000000")),
             None,
             None,

--- a/src/models/transactions/nftoken_create_offer.rs
+++ b/src/models/transactions/nftoken_create_offer.rs
@@ -96,7 +96,7 @@ pub struct NFTokenCreateOffer<'a> {
     #[serde(with = "txn_flags")]
     pub flags: Option<Vec<NFTokenCreateOfferFlag>>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -266,7 +266,7 @@ impl<'a> NFTokenCreateOffer<'a> {
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
         flags: Option<Vec<NFTokenCreateOfferFlag>>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         owner: Option<&'a str>,
         expiration: Option<u32>,

--- a/src/models/transactions/nftoken_mint.rs
+++ b/src/models/transactions/nftoken_mint.rs
@@ -1,6 +1,6 @@
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use anyhow::Result;
-use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;

--- a/src/models/transactions/nftoken_mint.rs
+++ b/src/models/transactions/nftoken_mint.rs
@@ -102,7 +102,7 @@ pub struct NFTokenMint<'a> {
     #[serde(with = "txn_flags")]
     pub flags: Option<Vec<NFTokenMintFlag>>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -247,7 +247,7 @@ impl<'a> NFTokenMint<'a> {
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
         flags: Option<Vec<NFTokenMintFlag>>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         issuer: Option<&'a str>,
         transfer_fee: Option<u32>,
@@ -376,6 +376,7 @@ mod test_nftoken_mint_error {
 
 #[cfg(test)]
 mod test_serde {
+    use alloc::string::ToString;
     use alloc::vec;
 
     use super::*;
@@ -394,7 +395,7 @@ mod test_serde {
             None,
             None,
             Some(vec![NFTokenMintFlag::TfTransferable]),
-            Some(vec![Memo::new(Some("72656E74"), None, Some("687474703A2F2F6578616D706C652E636F6D2F6D656D6F2F67656E65726963"))]),
+            Some(vec![Memo::new(Some("72656E74".to_string()), None, Some("687474703A2F2F6578616D706C652E636F6D2F6D656D6F2F67656E65726963".to_string()))]),
             None,
             None,
             Some(314),
@@ -422,7 +423,7 @@ mod test_serde {
             None,
             None,
             Some(vec![NFTokenMintFlag::TfTransferable]),
-            Some(vec![Memo::new(Some("72656E74"), None, Some("687474703A2F2F6578616D706C652E636F6D2F6D656D6F2F67656E65726963"))]),
+            Some(vec![Memo::new(Some("72656E74".to_string()), None, Some("687474703A2F2F6578616D706C652E636F6D2F6D656D6F2F67656E65726963".to_string()))]),
             None,
             None,
             Some(314),

--- a/src/models/transactions/nftoken_mint.rs
+++ b/src/models/transactions/nftoken_mint.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use anyhow::Result;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
@@ -60,7 +61,7 @@ pub struct NFTokenMint<'a> {
     #[serde(default = "TransactionType::nftoken_mint")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -80,11 +81,11 @@ pub struct NFTokenMint<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -96,7 +97,7 @@ pub struct NFTokenMint<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     #[serde(default)]
     #[serde(with = "txn_flags")]
@@ -114,10 +115,10 @@ pub struct NFTokenMint<'a> {
     /// `<https://xrpl.org/nftokenmint.html#nftokenmint-fields>`
     #[serde(rename = "NFTokenTaxon")]
     pub nftoken_taxon: u32,
-    pub issuer: Option<&'a str>,
+    pub issuer: Option<Cow<'a, str>>,
     pub transfer_fee: Option<u32>,
     #[serde(rename = "URI")]
-    pub uri: Option<&'a str>,
+    pub uri: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for NFTokenMint<'a> {
@@ -184,12 +185,12 @@ impl<'a> Transaction for NFTokenMint<'a> {
 
 impl<'a> NFTokenMintError for NFTokenMint<'a> {
     fn _get_issuer_error(&self) -> Result<(), XRPLNFTokenMintException> {
-        if let Some(issuer) = self.issuer {
+        if let Some(issuer) = self.issuer.clone() {
             if issuer == self.account {
                 Err(XRPLNFTokenMintException::ValueEqualsValue {
-                    field1: "issuer",
-                    field2: "account",
-                    resource: "",
+                    field1: "issuer".into(),
+                    field2: "account".into(),
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -203,10 +204,10 @@ impl<'a> NFTokenMintError for NFTokenMint<'a> {
         if let Some(transfer_fee) = self.transfer_fee {
             if transfer_fee > MAX_TRANSFER_FEE {
                 Err(XRPLNFTokenMintException::ValueTooHigh {
-                    field: "transfer_fee",
+                    field: "transfer_fee".into(),
                     max: MAX_TRANSFER_FEE,
                     found: transfer_fee,
-                    resource: "",
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -217,13 +218,13 @@ impl<'a> NFTokenMintError for NFTokenMint<'a> {
     }
 
     fn _get_uri_error(&self) -> Result<(), XRPLNFTokenMintException> {
-        if let Some(uri) = self.uri {
+        if let Some(uri) = self.uri.clone() {
             if uri.len() > MAX_URI_LENGTH {
                 Err(XRPLNFTokenMintException::ValueTooLong {
-                    field: "uri",
+                    field: "uri".into(),
                     max: MAX_URI_LENGTH,
                     found: uri.len(),
-                    resource: "",
+                    resource: "".into(),
                 })
             } else {
                 Ok(())
@@ -236,22 +237,22 @@ impl<'a> NFTokenMintError for NFTokenMint<'a> {
 
 impl<'a> NFTokenMint<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         nftoken_taxon: u32,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         flags: Option<Vec<NFTokenMintFlag>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
-        issuer: Option<&'a str>,
+        issuer: Option<Cow<'a, str>>,
         transfer_fee: Option<u32>,
-        uri: Option<&'a str>,
+        uri: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::NFTokenMint,
@@ -293,7 +294,7 @@ mod test_nftoken_mint_error {
     fn test_issuer_error() {
         let nftoken_mint = NFTokenMint {
             transaction_type: TransactionType::NFTokenMint,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -306,7 +307,7 @@ mod test_nftoken_mint_error {
             memos: None,
             signers: None,
             nftoken_taxon: 0,
-            issuer: Some("rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb"),
+            issuer: Some("rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into()),
             transfer_fee: None,
             uri: None,
         };
@@ -321,7 +322,7 @@ mod test_nftoken_mint_error {
     fn test_transfer_fee_error() {
         let nftoken_mint = NFTokenMint {
             transaction_type: TransactionType::NFTokenMint,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -349,7 +350,7 @@ mod test_nftoken_mint_error {
     fn test_uri_error() {
         let nftoken_mint = NFTokenMint {
             transaction_type: TransactionType::NFTokenMint,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -364,7 +365,7 @@ mod test_nftoken_mint_error {
             nftoken_taxon: 0,
             issuer: None,
             transfer_fee: None,
-            uri: Some("wss://xrplcluster.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            uri: Some("wss://xrplcluster.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
         };
 
         assert_eq!(
@@ -384,7 +385,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = NFTokenMint::new(
-            "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B".into(),
             0,
             Some("10".into()),
             None,
@@ -399,7 +400,7 @@ mod test_serde {
             None,
             None,
             Some(314),
-            Some("697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469"),
+            Some("697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469".into()),
         );
         let default_json = r#"{"TransactionType":"NFTokenMint","Account":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","Fee":"10","Flags":8,"Memos":[{"Memo":{"MemoData":"72656E74","MemoFormat":null,"MemoType":"687474703A2F2F6578616D706C652E636F6D2F6D656D6F2F67656E65726963"}}],"NFTokenTaxon":0,"TransferFee":314,"URI":"697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469"}"#;
 
@@ -412,7 +413,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = NFTokenMint::new(
-            "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B".into(),
             0,
             Some("10".into()),
             None,
@@ -427,7 +428,7 @@ mod test_serde {
             None,
             None,
             Some(314),
-            Some("697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469"),
+            Some("697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469".into()),
         );
         let default_json = r#"{"TransactionType":"NFTokenMint","Account":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B","TransferFee":314,"NFTokenTaxon":0,"Flags":8,"Fee":"10","URI":"697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469","Memos":[{"Memo":{"MemoType":"687474703A2F2F6578616D706C652E636F6D2F6D656D6F2F67656E65726963","MemoFormat":null,"MemoData":"72656E74"}}]}"#;
 

--- a/src/models/transactions/offer_cancel.rs
+++ b/src/models/transactions/offer_cancel.rs
@@ -67,7 +67,7 @@ pub struct OfferCancel<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -121,7 +121,7 @@ impl<'a> OfferCancel<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
         Self {

--- a/src/models/transactions/offer_cancel.rs
+++ b/src/models/transactions/offer_cancel.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -27,7 +28,7 @@ pub struct OfferCancel<'a> {
     #[serde(default = "TransactionType::offer_cancel")]
     transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -47,11 +48,11 @@ pub struct OfferCancel<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -63,7 +64,7 @@ pub struct OfferCancel<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -111,16 +112,16 @@ impl<'a> Transaction for OfferCancel<'a> {
 
 impl<'a> OfferCancel<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         offer_sequence: u32,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
@@ -150,7 +151,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = OfferCancel::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
             6,
             Some("12".into()),
             Some(7),
@@ -174,7 +175,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = OfferCancel::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
             6,
             Some("12".into()),
             Some(7),

--- a/src/models/transactions/offer_cancel.rs
+++ b/src/models/transactions/offer_cancel.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/offer_create.rs
+++ b/src/models/transactions/offer_create.rs
@@ -105,7 +105,7 @@ pub struct OfferCreate<'a> {
     #[serde(with = "txn_flags")]
     pub flags: Option<Vec<OfferCreateFlag>>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -187,7 +187,7 @@ impl<'a> OfferCreate<'a> {
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
         flags: Option<Vec<OfferCreateFlag>>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         expiration: Option<u32>,
         offer_sequence: Option<u32>,

--- a/src/models/transactions/offer_create.rs
+++ b/src/models/transactions/offer_create.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
@@ -63,7 +64,7 @@ pub struct OfferCreate<'a> {
     #[serde(default = "TransactionType::offer_create")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -83,11 +84,11 @@ pub struct OfferCreate<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -99,7 +100,7 @@ pub struct OfferCreate<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     #[serde(default)]
     #[serde(with = "txn_flags")]
@@ -175,17 +176,17 @@ impl<'a> Transaction for OfferCreate<'a> {
 
 impl<'a> OfferCreate<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         taker_gets: Amount<'a>,
         taker_pays: Amount<'a>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         flags: Option<Vec<OfferCreateFlag>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
@@ -225,7 +226,7 @@ mod test {
     fn test_has_flag() {
         let txn: OfferCreate = OfferCreate {
             transaction_type: TransactionType::OfferCreate,
-            account: "rpXhhWmCvDwkzNtRbm7mmD1vZqdfatQNEe",
+            account: "rpXhhWmCvDwkzNtRbm7mmD1vZqdfatQNEe".into(),
             fee: Some("10".into()),
             sequence: Some(1),
             last_ledger_sequence: Some(72779837),
@@ -254,7 +255,7 @@ mod test {
     fn test_get_transaction_type() {
         let txn: OfferCreate = OfferCreate {
             transaction_type: TransactionType::OfferCreate,
-            account: "rpXhhWmCvDwkzNtRbm7mmD1vZqdfatQNEe",
+            account: "rpXhhWmCvDwkzNtRbm7mmD1vZqdfatQNEe".into(),
             fee: Some("10".into()),
             sequence: Some(1),
             last_ledger_sequence: Some(72779837),
@@ -290,7 +291,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = OfferCreate::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
             Amount::XRPAmount(XRPAmount::from("6000000")),
             Amount::IssuedCurrencyAmount(IssuedCurrencyAmount::new(
                 "GKO".into(),
@@ -322,7 +323,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = OfferCreate::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
             Amount::XRPAmount(XRPAmount::from("6000000")),
             Amount::IssuedCurrencyAmount(IssuedCurrencyAmount::new(
                 "GKO".into(),

--- a/src/models/transactions/offer_create.rs
+++ b/src/models/transactions/offer_create.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;

--- a/src/models/transactions/payment.rs
+++ b/src/models/transactions/payment.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};

--- a/src/models/transactions/payment.rs
+++ b/src/models/transactions/payment.rs
@@ -102,7 +102,7 @@ pub struct Payment<'a> {
     #[serde(with = "txn_flags")]
     pub flags: Option<Vec<PaymentFlag>>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -272,7 +272,7 @@ impl<'a> Payment<'a> {
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
         flags: Option<Vec<PaymentFlag>>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         destination_tag: Option<u32>,
         invoice_id: Option<u32>,

--- a/src/models/transactions/payment_channel_claim.rs
+++ b/src/models/transactions/payment_channel_claim.rs
@@ -101,7 +101,7 @@ pub struct PaymentChannelClaim<'a> {
     #[serde(with = "txn_flags")]
     pub flags: Option<Vec<PaymentChannelClaimFlag>>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -186,7 +186,7 @@ impl<'a> PaymentChannelClaim<'a> {
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
         flags: Option<Vec<PaymentChannelClaimFlag>>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         balance: Option<&'a str>,
         amount: Option<&'a str>,

--- a/src/models/transactions/payment_channel_claim.rs
+++ b/src/models/transactions/payment_channel_claim.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
@@ -59,7 +60,7 @@ pub struct PaymentChannelClaim<'a> {
     #[serde(default = "TransactionType::payment_channel_claim")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -79,11 +80,11 @@ pub struct PaymentChannelClaim<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -95,7 +96,7 @@ pub struct PaymentChannelClaim<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     #[serde(default)]
     #[serde(with = "txn_flags")]
@@ -111,11 +112,11 @@ pub struct PaymentChannelClaim<'a> {
     ///
     /// See PaymentChannelClaim fields:
     /// `<https://xrpl.org/paymentchannelclaim.html#paymentchannelclaim-fields>`
-    pub channel: &'a str,
-    pub balance: Option<&'a str>,
-    pub amount: Option<&'a str>,
-    pub signature: Option<&'a str>,
-    pub public_key: Option<&'a str>,
+    pub channel: Cow<'a, str>,
+    pub balance: Option<Cow<'a, str>>,
+    pub amount: Option<Cow<'a, str>>,
+    pub signature: Option<Cow<'a, str>>,
+    pub public_key: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for PaymentChannelClaim<'a> {
@@ -175,23 +176,23 @@ impl<'a> Transaction for PaymentChannelClaim<'a> {
 
 impl<'a> PaymentChannelClaim<'a> {
     pub fn new(
-        account: &'a str,
-        channel: &'a str,
+        account: Cow<'a, str>,
+        channel: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         flags: Option<Vec<PaymentChannelClaimFlag>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
-        balance: Option<&'a str>,
-        amount: Option<&'a str>,
-        signature: Option<&'a str>,
-        public_key: Option<&'a str>,
+        balance: Option<Cow<'a, str>>,
+        amount: Option<Cow<'a, str>>,
+        signature: Option<Cow<'a, str>>,
+        public_key: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::PaymentChannelClaim,
@@ -223,8 +224,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = PaymentChannelClaim::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
+            "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198".into(),
             None,
             None,
             None,
@@ -236,10 +237,10 @@ mod test_serde {
             None,
             None,
             None,
-            Some("1000000"),
-            Some("1000000"),
-            Some("30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B"),
-            Some("32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"),
+            Some("1000000".into()),
+            Some("1000000".into()),
+            Some("30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B".into()),
+            Some("32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A".into()),
         );
         let default_json = r#"{"TransactionType":"PaymentChannelClaim","Account":"ra5nK24KXen9AHvsdFTKHSANinZseWnPcX","Channel":"C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198","Balance":"1000000","Amount":"1000000","Signature":"30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B","PublicKey":"32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"}"#;
 
@@ -252,8 +253,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = PaymentChannelClaim::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
-            "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
+            "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198".into(),
             None,
             None,
             None,
@@ -265,10 +266,10 @@ mod test_serde {
             None,
             None,
             None,
-            Some("1000000"),
-            Some("1000000"),
-            Some("30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B"),
-            Some("32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"),
+            Some("1000000".into()),
+            Some("1000000".into()),
+            Some("30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B".into()),
+            Some("32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A".into()),
         );
         let default_json = r#"{"TransactionType":"PaymentChannelClaim","Account":"ra5nK24KXen9AHvsdFTKHSANinZseWnPcX","Channel":"C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198","Balance":"1000000","Amount":"1000000","Signature":"30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B","PublicKey":"32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"}"#;
 

--- a/src/models/transactions/payment_channel_claim.rs
+++ b/src/models/transactions/payment_channel_claim.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;

--- a/src/models/transactions/payment_channel_create.rs
+++ b/src/models/transactions/payment_channel_create.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -27,7 +28,7 @@ pub struct PaymentChannelCreate<'a> {
     #[serde(default = "TransactionType::payment_channel_create")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -47,11 +48,11 @@ pub struct PaymentChannelCreate<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -63,7 +64,7 @@ pub struct PaymentChannelCreate<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -78,9 +79,9 @@ pub struct PaymentChannelCreate<'a> {
     /// See PaymentChannelCreate fields:
     /// `<https://xrpl.org/paymentchannelcreate.html#paymentchannelcreate-fields>`
     pub amount: XRPAmount<'a>,
-    pub destination: &'a str,
+    pub destination: Cow<'a, str>,
     pub settle_delay: u32,
-    pub public_key: &'a str,
+    pub public_key: Cow<'a, str>,
     pub cancel_after: Option<u32>,
     pub destination_tag: Option<u32>,
 }
@@ -121,19 +122,19 @@ impl<'a> Transaction for PaymentChannelCreate<'a> {
 
 impl<'a> PaymentChannelCreate<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         amount: XRPAmount<'a>,
-        destination: &'a str,
+        destination: Cow<'a, str>,
         settle_delay: u32,
-        public_key: &'a str,
+        public_key: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         cancel_after: Option<u32>,
@@ -170,11 +171,11 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = PaymentChannelCreate::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             XRPAmount::from("10000"),
-            "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+            "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW".into(),
             86400,
-            "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+            "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A".into(),
             None,
             None,
             None,
@@ -199,11 +200,11 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = PaymentChannelCreate::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             XRPAmount::from("10000"),
-            "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+            "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW".into(),
             86400,
-            "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+            "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A".into(),
             None,
             None,
             None,

--- a/src/models/transactions/payment_channel_create.rs
+++ b/src/models/transactions/payment_channel_create.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/payment_channel_create.rs
+++ b/src/models/transactions/payment_channel_create.rs
@@ -67,7 +67,7 @@ pub struct PaymentChannelCreate<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -134,7 +134,7 @@ impl<'a> PaymentChannelCreate<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         cancel_after: Option<u32>,
         destination_tag: Option<u32>,

--- a/src/models/transactions/payment_channel_fund.rs
+++ b/src/models/transactions/payment_channel_fund.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -28,7 +29,7 @@ pub struct PaymentChannelFund<'a> {
     #[serde(default = "TransactionType::payment_channel_fund")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -48,11 +49,11 @@ pub struct PaymentChannelFund<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -64,7 +65,7 @@ pub struct PaymentChannelFund<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -79,7 +80,7 @@ pub struct PaymentChannelFund<'a> {
     /// See PaymentChannelFund fields:
     /// `<https://xrpl.org/paymentchannelfund.html#paymentchannelfund-fields>`
     pub amount: XRPAmount<'a>,
-    pub channel: &'a str,
+    pub channel: Cow<'a, str>,
     pub expiration: Option<u32>,
 }
 
@@ -116,17 +117,17 @@ impl<'a> Transaction for PaymentChannelFund<'a> {
 
 impl<'a> PaymentChannelFund<'a> {
     pub fn new(
-        account: &'a str,
-        channel: &'a str,
+        account: Cow<'a, str>,
+        channel: Cow<'a, str>,
         amount: XRPAmount<'a>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         expiration: Option<u32>,
@@ -161,8 +162,8 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = PaymentChannelFund::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+            "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198".into(),
             XRPAmount::from("200000"),
             None,
             None,
@@ -187,8 +188,8 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = PaymentChannelFund::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-            "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+            "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198".into(),
             XRPAmount::from("200000"),
             None,
             None,

--- a/src/models/transactions/payment_channel_fund.rs
+++ b/src/models/transactions/payment_channel_fund.rs
@@ -68,7 +68,7 @@ pub struct PaymentChannelFund<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -127,7 +127,7 @@ impl<'a> PaymentChannelFund<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         expiration: Option<u32>,
     ) -> Self {

--- a/src/models/transactions/payment_channel_fund.rs
+++ b/src/models/transactions/payment_channel_fund.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/pseudo_transactions/enable_amendment.rs
+++ b/src/models/transactions/pseudo_transactions/enable_amendment.rs
@@ -1,4 +1,5 @@
 use crate::_serde::txn_flags;
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -41,7 +42,7 @@ pub struct EnableAmendment<'a> {
     #[serde(default = "TransactionType::enable_amendment")]
     transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -55,7 +56,7 @@ pub struct EnableAmendment<'a> {
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -63,7 +64,7 @@ pub struct EnableAmendment<'a> {
     pub source_tag: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     #[serde(default)]
     #[serde(with = "txn_flags")]
@@ -72,7 +73,7 @@ pub struct EnableAmendment<'a> {
     ///
     /// See EnableAmendment fields:
     /// `<https://xrpl.org/enableamendment.html#enableamendment-fields>`
-    pub amendment: &'a str,
+    pub amendment: Cow<'a, str>,
     pub ledger_sequence: u32,
 }
 
@@ -104,14 +105,14 @@ impl<'a> Transaction for EnableAmendment<'a> {
 
 impl<'a> EnableAmendment<'a> {
     pub fn new(
-        account: &'a str,
-        amendment: &'a str,
+        account: Cow<'a, str>,
+        amendment: Cow<'a, str>,
         ledger_sequence: u32,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
-        signing_pub_key: Option<&'a str>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         flags: Option<Vec<EnableAmendmentFlag>>,
     ) -> Self {
         Self {

--- a/src/models/transactions/pseudo_transactions/set_fee.rs
+++ b/src/models/transactions/pseudo_transactions/set_fee.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -24,7 +25,7 @@ pub struct SetFee<'a> {
     #[serde(default = "TransactionType::set_fee")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -38,7 +39,7 @@ pub struct SetFee<'a> {
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -46,7 +47,7 @@ pub struct SetFee<'a> {
     pub source_tag: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// The custom fields for the SetFee model.
@@ -70,7 +71,7 @@ impl<'a> Transaction for SetFee<'a> {
 
 impl<'a> SetFee<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         base_fee: XRPAmount<'a>,
         reference_fee_units: u32,
         reserve_base: u32,
@@ -78,9 +79,9 @@ impl<'a> SetFee<'a> {
         ledger_sequence: u32,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
-        signing_pub_key: Option<&'a str>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::SetFee,

--- a/src/models/transactions/pseudo_transactions/unl_modify.rs
+++ b/src/models/transactions/pseudo_transactions/unl_modify.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
@@ -35,7 +36,7 @@ pub struct UNLModify<'a> {
     #[serde(default = "TransactionType::unl_modify")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -49,7 +50,7 @@ pub struct UNLModify<'a> {
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -57,7 +58,7 @@ pub struct UNLModify<'a> {
     pub source_tag: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// The custom fields for the UNLModify model.
@@ -66,7 +67,7 @@ pub struct UNLModify<'a> {
     /// `<https://xrpl.org/unlmodify.html#unlmodify-fields>`
     pub ledger_sequence: u32,
     pub unlmodify_disabling: UNLModifyDisabling,
-    pub unlmodify_validator: &'a str,
+    pub unlmodify_validator: Cow<'a, str>,
 }
 
 impl<'a> Model for UNLModify<'a> {}
@@ -79,15 +80,15 @@ impl<'a> Transaction for UNLModify<'a> {
 
 impl<'a> UNLModify<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         ledger_sequence: u32,
         unlmodify_disabling: UNLModifyDisabling,
-        unlmodify_validator: &'a str,
+        unlmodify_validator: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
-        signing_pub_key: Option<&'a str>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::UNLModify,

--- a/src/models/transactions/set_regular_key.rs
+++ b/src/models/transactions/set_regular_key.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -31,7 +32,7 @@ pub struct SetRegularKey<'a> {
     #[serde(default = "TransactionType::set_regular_key")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -51,11 +52,11 @@ pub struct SetRegularKey<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -67,7 +68,7 @@ pub struct SetRegularKey<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -81,7 +82,7 @@ pub struct SetRegularKey<'a> {
     ///
     /// See SetRegularKey fields:
     /// `<https://xrpl.org/setregularkey.html#setregularkey-fields>`
-    pub regular_key: Option<&'a str>,
+    pub regular_key: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for SetRegularKey<'a> {
@@ -115,18 +116,18 @@ impl<'a> Transaction for SetRegularKey<'a> {
 
 impl<'a> SetRegularKey<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
-        regular_key: Option<&'a str>,
+        regular_key: Option<Cow<'a, str>>,
     ) -> Self {
         Self {
             transaction_type: TransactionType::SetRegularKey,
@@ -154,7 +155,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = SetRegularKey::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             Some("12".into()),
             None,
             None,
@@ -165,7 +166,7 @@ mod test_serde {
             None,
             None,
             None,
-            Some("rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD"),
+            Some("rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD".into()),
         );
         let default_json = r#"{"TransactionType":"SetRegularKey","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Fee":"12","RegularKey":"rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD"}"#;
 
@@ -178,7 +179,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = SetRegularKey::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             Some("12".into()),
             None,
             None,
@@ -189,7 +190,7 @@ mod test_serde {
             None,
             None,
             None,
-            Some("rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD"),
+            Some("rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD".into()),
         );
         let default_json = r#"{"TransactionType":"SetRegularKey","Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Fee":"12","RegularKey":"rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD"}"#;
 

--- a/src/models/transactions/set_regular_key.rs
+++ b/src/models/transactions/set_regular_key.rs
@@ -71,7 +71,7 @@ pub struct SetRegularKey<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -124,7 +124,7 @@ impl<'a> SetRegularKey<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         regular_key: Option<&'a str>,
     ) -> Self {

--- a/src/models/transactions/set_regular_key.rs
+++ b/src/models/transactions/set_regular_key.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/signer_list_set.rs
+++ b/src/models/transactions/signer_list_set.rs
@@ -1,5 +1,6 @@
 use alloc::string::ToString;
 use alloc::string::String;
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use anyhow::Result;
 use derive_new::new;
@@ -45,7 +46,7 @@ pub struct SignerListSet<'a> {
     #[serde(default = "TransactionType::signer_list_set")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -65,11 +66,11 @@ pub struct SignerListSet<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -81,7 +82,7 @@ pub struct SignerListSet<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -197,7 +198,7 @@ impl<'a> SignerListSetError for SignerListSet<'a> {
             if accounts.contains(&self.account.to_string()) {
                 Err(XRPLSignerListSetException::CollectionInvalidItem {
                     field: "signer_entries".into(),
-                    found: self.account.into(),
+                    found: self.account.clone(),
                     resource: "".into(),
                 })
             } else if self.signer_quorum > signer_weight_sum {
@@ -226,16 +227,16 @@ impl<'a> SignerListSetError for SignerListSet<'a> {
 
 impl<'a> SignerListSet<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         signer_quorum: u32,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         signer_entries: Option<Vec<SignerEntry>>,
@@ -278,7 +279,7 @@ mod test_signer_list_set_error {
     fn test_signer_list_deleted_error() {
         let mut signer_list_set = SignerListSet {
             transaction_type: TransactionType::SignerListSet,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -315,7 +316,7 @@ mod test_signer_list_set_error {
     fn test_signer_entries_error() {
         let mut signer_list_set = SignerListSet {
             transaction_type: TransactionType::SignerListSet,
-            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb",
+            account: "rU4EE1FskCPJw5QkLx1iGgdWiJa6HeqYyb".into(),
             fee: None,
             sequence: None,
             last_ledger_sequence: None,
@@ -440,7 +441,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = SignerListSet::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             3,
             Some("12".into()),
             None,
@@ -469,7 +470,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = SignerListSet::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             3,
             Some("12".into()),
             None,

--- a/src/models/transactions/signer_list_set.rs
+++ b/src/models/transactions/signer_list_set.rs
@@ -1,6 +1,6 @@
-use alloc::string::ToString;
-use alloc::string::String;
 use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 use anyhow::Result;
 use derive_new::new;

--- a/src/models/transactions/ticket_create.rs
+++ b/src/models/transactions/ticket_create.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/src/models/transactions/ticket_create.rs
+++ b/src/models/transactions/ticket_create.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -27,7 +28,7 @@ pub struct TicketCreate<'a> {
     #[serde(default = "TransactionType::ticket_create")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -47,11 +48,11 @@ pub struct TicketCreate<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -63,7 +64,7 @@ pub struct TicketCreate<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
@@ -111,16 +112,16 @@ impl<'a> Transaction for TicketCreate<'a> {
 
 impl<'a> TicketCreate<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         ticket_count: u32,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
@@ -150,7 +151,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = TicketCreate::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             10,
             Some("10".into()),
             Some(381),
@@ -174,7 +175,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = TicketCreate::new(
-            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
             10,
             Some("10".into()),
             Some(381),

--- a/src/models/transactions/ticket_create.rs
+++ b/src/models/transactions/ticket_create.rs
@@ -67,7 +67,7 @@ pub struct TicketCreate<'a> {
     /// Set of bit-flags for this transaction.
     pub flags: Option<u32>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -121,7 +121,7 @@ impl<'a> TicketCreate<'a> {
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
     ) -> Self {
         Self {

--- a/src/models/transactions/trust_set.rs
+++ b/src/models/transactions/trust_set.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
@@ -54,7 +55,7 @@ pub struct TrustSet<'a> {
     #[serde(default = "TransactionType::trust_set")]
     pub transaction_type: TransactionType,
     /// The unique address of the account that initiated the transaction.
-    pub account: &'a str,
+    pub account: Cow<'a, str>,
     /// Integer amount of XRP, in drops, to be destroyed as a cost
     /// for distributing this transaction to the network. Some
     /// transaction types have different minimum requirements.
@@ -74,11 +75,11 @@ pub struct TrustSet<'a> {
     /// transaction is only valid if the sending account's
     /// previously-sent transaction matches the provided hash.
     #[serde(rename = "AccountTxnID")]
-    pub account_txn_id: Option<&'a str>,
+    pub account_txn_id: Option<Cow<'a, str>>,
     /// Hex representation of the public key that corresponds to the
     /// private key used to sign this transaction. If an empty string,
     /// indicates a multi-signature is present in the Signers field instead.
-    pub signing_pub_key: Option<&'a str>,
+    pub signing_pub_key: Option<Cow<'a, str>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction
     /// is made. Conventionally, a refund should specify the initial
@@ -90,7 +91,7 @@ pub struct TrustSet<'a> {
     pub ticket_sequence: Option<u32>,
     /// The signature that verifies this transaction as originating
     /// from the account it says it is from.
-    pub txn_signature: Option<&'a str>,
+    pub txn_signature: Option<Cow<'a, str>>,
     /// Set of bit-flags for this transaction.
     #[serde(default)]
     #[serde(with = "txn_flags")]
@@ -163,16 +164,16 @@ impl<'a> Transaction for TrustSet<'a> {
 
 impl<'a> TrustSet<'a> {
     pub fn new(
-        account: &'a str,
+        account: Cow<'a, str>,
         limit_amount: IssuedCurrencyAmount<'a>,
         fee: Option<XRPAmount<'a>>,
         sequence: Option<u32>,
         last_ledger_sequence: Option<u32>,
-        account_txn_id: Option<&'a str>,
-        signing_pub_key: Option<&'a str>,
+        account_txn_id: Option<Cow<'a, str>>,
+        signing_pub_key: Option<Cow<'a, str>>,
         source_tag: Option<u32>,
         ticket_sequence: Option<u32>,
-        txn_signature: Option<&'a str>,
+        txn_signature: Option<Cow<'a, str>>,
         flags: Option<Vec<TrustSetFlag>>,
         memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
@@ -208,7 +209,7 @@ mod test_serde {
     #[test]
     fn test_serialize() {
         let default_txn = TrustSet::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
             IssuedCurrencyAmount::new(
                 "USD".into(),
                 "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc".into(),
@@ -239,7 +240,7 @@ mod test_serde {
     #[test]
     fn test_deserialize() {
         let default_txn = TrustSet::new(
-            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+            "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX".into(),
             IssuedCurrencyAmount::new(
                 "USD".into(),
                 "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc".into(),

--- a/src/models/transactions/trust_set.rs
+++ b/src/models/transactions/trust_set.rs
@@ -96,7 +96,7 @@ pub struct TrustSet<'a> {
     #[serde(with = "txn_flags")]
     pub flags: Option<Vec<TrustSetFlag>>,
     /// Additional arbitrary information used to identify this transaction.
-    pub memos: Option<Vec<Memo<'a>>>,
+    pub memos: Option<Vec<Memo>>,
     /// Arbitrary integer used to identify the reason for this
     /// payment, or a sender on whose behalf this transaction is
     /// made. Conventionally, a refund should specify the initial
@@ -174,7 +174,7 @@ impl<'a> TrustSet<'a> {
         ticket_sequence: Option<u32>,
         txn_signature: Option<&'a str>,
         flags: Option<Vec<TrustSetFlag>>,
-        memos: Option<Vec<Memo<'a>>>,
+        memos: Option<Vec<Memo>>,
         signers: Option<Vec<Signer<'a>>>,
         quality_in: Option<u32>,
         quality_out: Option<u32>,

--- a/src/models/transactions/trust_set.rs
+++ b/src/models/transactions/trust_set.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;

--- a/tests/integration/clients/mod.rs
+++ b/tests/integration/clients/mod.rs
@@ -11,7 +11,7 @@ async fn test_websocket_tungstenite_echo() -> Result<()> {
 
     let mut websocket = connect_to_wss_tungstinite_echo().await?;
     let account_info = AccountInfo::new(
-        "rJumr5e1HwiuV543H7bqixhtFreChWTaHH",
+        "rJumr5e1HwiuV543H7bqixhtFreChWTaHH".into(),
         None,
         None,
         None,
@@ -52,7 +52,7 @@ async fn test_embedded_websocket_echo() -> Result<()> {
     let mut websocket =
         connect_to_ws_embedded_websocket_tokio_echo(&mut framed, &mut buffer).await?;
     let account_info = AccountInfo::new(
-        "rJumr5e1HwiuV543H7bqixhtFreChWTaHH",
+        "rJumr5e1HwiuV543H7bqixhtFreChWTaHH".into(),
         None,
         None,
         None,


### PR DESCRIPTION
## High Level Overview of Change

This PR utilizes `Cow` for all `&'a str` types in the models. It also uses `String` instead of `Cow` for structs that utilize the `serde_with_tag` macro as it caused lifetime issues with `serde::Deserialize`. This may change back as soon as we found a solution for this issue.

### Context of Change

The lifetime issue is one I encountered during #71 development. We use `String` in favor of #71.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change that only restructures code)