### PR TITLE
Add JsonRPC Clients

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -6,6 +6,7 @@ cargo fmt
 cargo test --no-default-features --features core,models,utils
 cargo test --no-default-features --features core,models,utils,embedded-ws
 cargo test --no-default-features --features core,models,utils,tungstenite
+cargo test --no-default-features --features core,models,utils,json-rpc-std
 cargo test --all-features
 cargo clippy --fix --allow-staged
 cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ tokio-util = { version = "0.7.7", features = ["codec"], optional = true }
 bytes = { version = "1.4.0", default-features = false }
 embassy-futures = "0.1.1"
 embedded-websocket = { version = "0.9.3", optional = true }
+reqwless = { version = "0.12.0", optional = true }
+embedded-nal-async = "0.7.1"
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -94,7 +96,7 @@ name = "benchmarks"
 harness = false
 
 [features]
-default = ["std", "core", "models", "utils", "tungstenite"]
+default = ["std", "core", "models", "utils", "tungstenite", "json-rpc"]
 models = ["core", "transactions", "requests", "ledger", "results"]
 transactions = ["core", "amounts", "currencies"]
 requests = ["core", "amounts", "currencies"]
@@ -102,6 +104,7 @@ results = ["core", "amounts", "currencies"]
 ledger = ["core", "amounts", "currencies"]
 amounts = ["core"]
 currencies = ["core"]
+json-rpc = ["reqwless"]
 tungstenite = [
     "url",
     "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,8 @@ bytes = { version = "1.4.0", default-features = false }
 embassy-futures = "0.1.1"
 embedded-websocket = { version = "0.9.3", optional = true }
 reqwless = { version = "0.12.0", optional = true }
-embedded-nal-async = "0.7.1"
+embedded-nal-async = { version = "0.7.1", optional = true }
+reqwest = { version = "0.12.4", features = ["json"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -96,7 +97,7 @@ name = "benchmarks"
 harness = false
 
 [features]
-default = ["std", "core", "models", "utils", "tungstenite", "json-rpc"]
+default = ["std", "core", "models", "utils", "tungstenite", "json-rpc-std"]
 models = ["core", "transactions", "requests", "ledger", "results"]
 transactions = ["core", "amounts", "currencies"]
 requests = ["core", "amounts", "currencies"]
@@ -104,7 +105,8 @@ results = ["core", "amounts", "currencies"]
 ledger = ["core", "amounts", "currencies"]
 amounts = ["core"]
 currencies = ["core"]
-json-rpc = ["reqwless"]
+json-rpc = ["reqwless", "embedded-nal-async"]
+json-rpc-std = ["reqwest"]
 tungstenite = [
     "url",
     "futures",

--- a/src/asynch/clients/json_rpc/exceptions.rs
+++ b/src/asynch/clients/json_rpc/exceptions.rs
@@ -1,7 +1,8 @@
-use strum_macros::Display;
 use thiserror_no_std::Error;
 
-#[derive(Debug, Error, Display)]
+#[derive(Debug, Error)]
 pub enum XRPLJsonRpcException {
-    ReqwlessError(reqwless::Error),
+    #[cfg(feature = "json-rpc")]
+    #[error("Reqwless error")]
+    ReqwlessError,
 }

--- a/src/asynch/clients/json_rpc/exceptions.rs
+++ b/src/asynch/clients/json_rpc/exceptions.rs
@@ -1,0 +1,7 @@
+use strum_macros::Display;
+use thiserror_no_std::Error;
+
+#[derive(Debug, Error, Display)]
+pub enum XRPLJsonRpcException {
+    ReqwlessError(reqwless::Error),
+}

--- a/src/asynch/clients/json_rpc/mod.rs
+++ b/src/asynch/clients/json_rpc/mod.rs
@@ -1,0 +1,86 @@
+use alloc::{borrow::Cow, sync::Arc};
+use anyhow::Result;
+use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
+use embedded_nal_async::{Dns, TcpConnect};
+use reqwless::{
+    client::HttpClient,
+    headers::ContentType,
+    request::{Method, RequestBuilder},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::{requests::Request, results::XRPLResponse},
+    Err,
+};
+
+mod exceptions;
+pub use exceptions::XRPLJsonRpcException;
+
+use super::{client::Client, SingleExecutorMutex};
+
+pub struct AsyncJsonRpcClient<'a, const BUF: usize, T, D, M = SingleExecutorMutex>
+where
+    M: RawMutex,
+    T: TcpConnect + 'a,
+    D: Dns + 'a,
+{
+    url: Cow<'a, str>,
+    client: Arc<Mutex<M, HttpClient<'a, T, D>>>,
+}
+
+impl<'a, const BUF: usize, T, D, M> AsyncJsonRpcClient<'a, BUF, T, D, M>
+where
+    M: RawMutex,
+    T: TcpConnect + 'a,
+    D: Dns + 'a,
+{
+    pub fn new(url: Cow<'a, str>, tcp: &'a T, dns: &'a D) -> Self {
+        Self {
+            url,
+            client: Arc::new(Mutex::new(HttpClient::new(tcp, dns))),
+        }
+    }
+}
+
+impl<'a, const BUF: usize, T, D, M> Client<'a> for AsyncJsonRpcClient<'a, BUF, T, D, M>
+where
+    M: RawMutex,
+    T: TcpConnect + 'a,
+    D: Dns + 'a,
+{
+    async fn request_impl<
+        Res: Serialize + for<'de> Deserialize<'de>,
+        Req: Serialize + for<'de> Deserialize<'de> + Request<'a>,
+    >(
+        &'a self,
+        request: Req,
+    ) -> Result<XRPLResponse<'_, Res, Req>> {
+        let request_buf = match serde_json::to_vec(&request) {
+            Ok(request) => request,
+            Err(error) => return Err!(error),
+        };
+        let mut rx_buffer = [0; BUF];
+        let mut client = self.client.lock().await;
+        let response = match client.request(Method::POST, &self.url).await {
+            Ok(client) => {
+                if let Err(error) = client
+                    .body(request_buf.as_slice())
+                    .content_type(ContentType::TextPlain)
+                    .send(&mut rx_buffer)
+                    .await
+                {
+                    Err!(XRPLJsonRpcException::ReqwlessError(error))
+                } else {
+                    match serde_json::from_slice::<XRPLResponse<'_, Res, Req>>(&rx_buffer) {
+                        Ok(response) => Ok(response),
+                        Err(error) => Err!(error),
+                    }
+                }
+            }
+            Err(error) => Err!(XRPLJsonRpcException::ReqwlessError(error)),
+        };
+
+        response
+    }
+}

--- a/src/asynch/clients/json_rpc/mod.rs
+++ b/src/asynch/clients/json_rpc/mod.rs
@@ -180,7 +180,7 @@ mod no_std_client {
     }
 }
 
-#[cfg(feature = "json-rpc")]
+#[cfg(all(feature = "json-rpc", not(feature = "json-rpc-std")))]
 pub use no_std_client::AsyncJsonRpcClient;
-#[cfg(feature = "json-rpc-std")]
+#[cfg(all(feature = "json-rpc-std", not(feature = "json-rpc")))]
 pub use std_client::AsyncJsonRpcClient;

--- a/src/asynch/clients/json_rpc/mod.rs
+++ b/src/asynch/clients/json_rpc/mod.rs
@@ -1,12 +1,6 @@
-use alloc::{borrow::Cow, sync::Arc};
+use alloc::{string::String, sync::Arc};
 use anyhow::Result;
 use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
-use embedded_nal_async::{Dns, TcpConnect};
-use reqwless::{
-    client::HttpClient,
-    headers::ContentType,
-    request::{Method, RequestBuilder},
-};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -19,68 +13,174 @@ pub use exceptions::XRPLJsonRpcException;
 
 use super::{client::Client, SingleExecutorMutex};
 
-pub struct AsyncJsonRpcClient<'a, const BUF: usize, T, D, M = SingleExecutorMutex>
-where
-    M: RawMutex,
-    T: TcpConnect + 'a,
-    D: Dns + 'a,
-{
-    url: Cow<'a, str>,
-    client: Arc<Mutex<M, HttpClient<'a, T, D>>>,
+/// Renames the requests field `command` to `method` for JSON-RPC.
+fn request_to_json_rpc(request: &impl Serialize) -> Result<String> {
+    let mut request = match serde_json::to_value(request) {
+        Ok(request) => request,
+        Err(error) => return Err!(error),
+    };
+    if let Some(command) = request.get_mut("command") {
+        let method = command.take();
+        request["method"] = method;
+    }
+    match serde_json::to_string(&request) {
+        Ok(request) => Ok(request),
+        Err(error) => Err!(error),
+    }
 }
 
-impl<'a, const BUF: usize, T, D, M> AsyncJsonRpcClient<'a, BUF, T, D, M>
-where
-    M: RawMutex,
-    T: TcpConnect + 'a,
-    D: Dns + 'a,
-{
-    pub fn new(url: Cow<'a, str>, tcp: &'a T, dns: &'a D) -> Self {
-        Self {
-            url,
-            client: Arc::new(Mutex::new(HttpClient::new(tcp, dns))),
+#[cfg(feature = "json-rpc-std")]
+mod std_client {
+    use super::*;
+    use reqwest::Client as HttpClient;
+    use url::Url;
+
+    pub struct AsyncJsonRpcClient<M = SingleExecutorMutex>
+    where
+        M: RawMutex,
+    {
+        url: Url,
+        client: Arc<Mutex<M, HttpClient>>,
+    }
+
+    impl<M> AsyncJsonRpcClient<M>
+    where
+        M: RawMutex,
+    {
+        pub fn new(url: Url) -> Self {
+            Self {
+                url,
+                client: Arc::new(Mutex::new(HttpClient::new())),
+            }
+        }
+    }
+
+    impl<M> AsyncJsonRpcClient<M>
+    where
+        M: RawMutex,
+    {
+        fn from(url: Url, client: HttpClient) -> Self {
+            Self {
+                url,
+                client: Arc::new(Mutex::new(client)),
+            }
+        }
+    }
+
+    impl<'a, M> Client<'a> for AsyncJsonRpcClient<M>
+    where
+        M: RawMutex,
+    {
+        async fn request_impl<
+            Res: Serialize + for<'de> Deserialize<'de>,
+            Req: Serialize + for<'de> Deserialize<'de> + Request<'a>,
+        >(
+            &'a self,
+            request: Req,
+        ) -> Result<XRPLResponse<'_, Res, Req>> {
+            let client = self.client.lock().await;
+            let response = match client
+                .post(self.url.as_ref())
+                .body(request_to_json_rpc(&request)?)
+                .send()
+                .await
+            {
+                Ok(response) => match response.json().await {
+                    Ok(response) => Ok(response),
+                    Err(error) => Err!(error),
+                },
+                Err(error) => Err!(error),
+            };
+
+            response
         }
     }
 }
 
-impl<'a, const BUF: usize, T, D, M> Client<'a> for AsyncJsonRpcClient<'a, BUF, T, D, M>
-where
-    M: RawMutex,
-    T: TcpConnect + 'a,
-    D: Dns + 'a,
-{
-    async fn request_impl<
-        Res: Serialize + for<'de> Deserialize<'de>,
-        Req: Serialize + for<'de> Deserialize<'de> + Request<'a>,
-    >(
-        &'a self,
-        request: Req,
-    ) -> Result<XRPLResponse<'_, Res, Req>> {
-        let request_buf = match serde_json::to_vec(&request) {
-            Ok(request) => request,
-            Err(error) => return Err!(error),
-        };
-        let mut rx_buffer = [0; BUF];
-        let mut client = self.client.lock().await;
-        let response = match client.request(Method::POST, &self.url).await {
-            Ok(client) => {
-                if let Err(error) = client
-                    .body(request_buf.as_slice())
-                    .content_type(ContentType::TextPlain)
-                    .send(&mut rx_buffer)
-                    .await
-                {
-                    Err!(XRPLJsonRpcException::ReqwlessError(error))
-                } else {
-                    match serde_json::from_slice::<XRPLResponse<'_, Res, Req>>(&rx_buffer) {
-                        Ok(response) => Ok(response),
-                        Err(error) => Err!(error),
+#[cfg(feature = "json-rpc")]
+mod no_std_client {
+    use super::*;
+    use embedded_nal_async::{Dns, TcpConnect};
+    use reqwless::{
+        client::{HttpClient, TlsConfig},
+        headers::ContentType,
+        request::{Method, RequestBuilder},
+    };
+    use url::Url;
+
+    pub struct AsyncJsonRpcClient<'a, const BUF: usize, T, D, M = SingleExecutorMutex>
+    where
+        M: RawMutex,
+        T: TcpConnect + 'a,
+        D: Dns + 'a,
+    {
+        url: Url,
+        client: Arc<Mutex<M, HttpClient<'a, T, D>>>,
+    }
+
+    impl<'a, const BUF: usize, T, D, M> AsyncJsonRpcClient<'a, BUF, T, D, M>
+    where
+        M: RawMutex,
+        T: TcpConnect + 'a,
+        D: Dns + 'a,
+    {
+        pub fn new(url: Url, tcp: &'a T, dns: &'a D) -> Self {
+            Self {
+                url,
+                client: Arc::new(Mutex::new(HttpClient::new(tcp, dns))),
+            }
+        }
+
+        pub fn new_with_tls(url: Url, tcp: &'a T, dns: &'a D, tls: TlsConfig<'a>) -> Self {
+            Self {
+                url,
+                client: Arc::new(Mutex::new(HttpClient::new_with_tls(tcp, dns, tls))),
+            }
+        }
+    }
+
+    impl<'a, const BUF: usize, T, D, M> Client<'a> for AsyncJsonRpcClient<'a, BUF, T, D, M>
+    where
+        M: RawMutex,
+        T: TcpConnect + 'a,
+        D: Dns + 'a,
+    {
+        async fn request_impl<
+            Res: Serialize + for<'de> Deserialize<'de>,
+            Req: Serialize + for<'de> Deserialize<'de> + Request<'a>,
+        >(
+            &'a self,
+            request: Req,
+        ) -> Result<XRPLResponse<'_, Res, Req>> {
+            let request_json_rpc = request_to_json_rpc(&request)?;
+            let request_buf = request_json_rpc.as_bytes();
+            let mut rx_buffer = [0; BUF];
+            let mut client = self.client.lock().await;
+            let response = match client.request(Method::POST, self.url.as_str()).await {
+                Ok(client) => {
+                    if let Err(_error) = client
+                        .body(request_buf)
+                        .content_type(ContentType::TextPlain)
+                        .send(&mut rx_buffer)
+                        .await
+                    {
+                        Err!(XRPLJsonRpcException::ReqwlessError)
+                    } else {
+                        match serde_json::from_slice::<XRPLResponse<'_, Res, Req>>(&rx_buffer) {
+                            Ok(response) => Ok(response),
+                            Err(error) => Err!(error),
+                        }
                     }
                 }
-            }
-            Err(error) => Err!(XRPLJsonRpcException::ReqwlessError(error)),
-        };
+                Err(_error) => Err!(XRPLJsonRpcException::ReqwlessError),
+            };
 
-        response
+            response
+        }
     }
 }
+
+#[cfg(feature = "json-rpc")]
+pub use no_std_client::AsyncJsonRpcClient;
+#[cfg(feature = "json-rpc-std")]
+pub use std_client::AsyncJsonRpcClient;

--- a/src/asynch/clients/json_rpc/mod.rs
+++ b/src/asynch/clients/json_rpc/mod.rs
@@ -79,7 +79,7 @@ mod std_client {
             request: Req,
         ) -> Result<XRPLResponse<'_, Res, Req>> {
             let client = self.client.lock().await;
-            let response = match client
+            match client
                 .post(self.url.as_ref())
                 .body(request_to_json_rpc(&request)?)
                 .send()
@@ -90,9 +90,7 @@ mod std_client {
                     Err(error) => Err!(error),
                 },
                 Err(error) => Err!(error),
-            };
-
-            response
+            }
         }
     }
 }

--- a/src/asynch/clients/mod.rs
+++ b/src/asynch/clients/mod.rs
@@ -1,6 +1,13 @@
 mod async_client;
 mod client;
+mod json_rpc;
 mod websocket;
 
+use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex};
+
+pub type MultiExecutorMutex = CriticalSectionRawMutex;
+pub type SingleExecutorMutex = NoopRawMutex;
+
 pub use async_client::*;
+pub use json_rpc::*;
 pub use websocket::*;

--- a/src/asynch/clients/websocket/embedded_websocket.rs
+++ b/src/asynch/clients/websocket/embedded_websocket.rs
@@ -22,7 +22,8 @@ use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::{SingleExecutorMutex, WebsocketClosed, WebsocketOpen};
+use super::{WebsocketClosed, WebsocketOpen};
+use crate::asynch::clients::SingleExecutorMutex;
 use crate::{
     asynch::clients::{
         client::Client as ClientTrait,

--- a/src/asynch/clients/websocket/mod.rs
+++ b/src/asynch/clients/websocket/mod.rs
@@ -6,11 +6,8 @@ use alloc::string::String;
 #[cfg(all(feature = "embedded-ws", not(feature = "tungstenite")))]
 use alloc::string::ToString;
 use anyhow::Result;
-use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex};
 #[cfg(all(feature = "embedded-ws", not(feature = "tungstenite")))]
 use embedded_io_async::{ErrorType, Read as EmbeddedIoRead, Write as EmbeddedIoWrite};
-#[cfg(all(feature = "embedded-ws", not(feature = "tungstenite")))]
-use exceptions::XRPLWebsocketException;
 #[cfg(all(feature = "tungstenite", not(feature = "embedded-ws")))]
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -22,7 +19,8 @@ use websocket_base::MessageHandler;
 pub mod codec;
 #[cfg(all(feature = "embedded-ws", not(feature = "tungstenite")))]
 mod embedded_websocket;
-pub mod exceptions;
+mod exceptions;
+pub use exceptions::XRPLWebsocketException;
 #[cfg(all(feature = "tungstenite", not(feature = "embedded-ws")))]
 mod tungstenite;
 
@@ -33,9 +31,6 @@ pub use tungstenite::AsyncWebsocketClient;
 
 pub struct WebsocketOpen;
 pub struct WebsocketClosed;
-
-pub type MultiExecutorMutex = CriticalSectionRawMutex;
-pub type SingleExecutorMutex = NoopRawMutex;
 
 #[allow(async_fn_in_trait)]
 pub trait XRPLWebsocketIO {

--- a/src/asynch/clients/websocket/tungstenite.rs
+++ b/src/asynch/clients/websocket/tungstenite.rs
@@ -1,7 +1,8 @@
 use super::exceptions::XRPLWebsocketException;
-use super::{SingleExecutorMutex, WebsocketClosed, WebsocketOpen};
+use super::{WebsocketClosed, WebsocketOpen};
 use crate::asynch::clients::client::Client;
 use crate::asynch::clients::websocket::websocket_base::{MessageHandler, WebsocketBase};
+use crate::asynch::clients::SingleExecutorMutex;
 use crate::models::requests::Request;
 use crate::models::results::XRPLResponse;
 use crate::Err;

--- a/src/asynch/clients/websocket/websocket_base.rs
+++ b/src/asynch/clients/websocket/websocket_base.rs
@@ -106,7 +106,7 @@ where
             }
             Ok(None) => Ok(None),
             Err(error) => {
-                return Err!(error);
+                Err!(error)
             }
         }
     }

--- a/src/asynch/clients/websocket/websocket_base.rs
+++ b/src/asynch/clients/websocket/websocket_base.rs
@@ -5,7 +5,8 @@ use futures::channel::oneshot::{self, Receiver, Sender};
 use hashbrown::HashMap;
 use serde_json::Value;
 
-use crate::{asynch::clients::exceptions::XRPLWebsocketException, Err};
+use super::exceptions::XRPLWebsocketException;
+use crate::Err;
 
 const _MAX_CHANNEL_MSG_CNT: usize = 10;
 

--- a/src/models/transactions/account_set.rs
+++ b/src/models/transactions/account_set.rs
@@ -230,7 +230,7 @@ impl<'a> AccountSetError for AccountSet<'a> {
         if self.clear_flag.is_some() && self.set_flag.is_some() && self.clear_flag == self.set_flag
         {
             Err(XRPLAccountSetException::SetAndUnsetSameFlag {
-                found: self.clear_flag.clone().unwrap(),
+                found: self.clear_flag.unwrap(),
                 resource: "".into(),
             })
         } else {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -87,9 +87,11 @@ impl Wallet {
 impl ToString for Wallet {
     /// Returns a string representation of a Wallet.
     fn to_string(&self) -> String {
-        let string_list = [format!("public_key: {}", self.public_key),
+        let string_list = [
+            format!("public_key: {}", self.public_key),
             format!("private_key: {}", "-HIDDEN-"),
-            format!("classic_address: {}", self.classic_address)];
+            format!("classic_address: {}", self.classic_address),
+        ];
 
         string_list.join("-")
     }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -10,7 +10,6 @@ use crate::core::keypairs::generate_seed;
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
-use alloc::vec;
 use zeroize::Zeroize;
 
 /// The cryptographic keys needed to control an
@@ -88,11 +87,9 @@ impl Wallet {
 impl ToString for Wallet {
     /// Returns a string representation of a Wallet.
     fn to_string(&self) -> String {
-        let string_list = vec![
-            format!("public_key: {}", self.public_key),
+        let string_list = [format!("public_key: {}", self.public_key),
             format!("private_key: {}", "-HIDDEN-"),
-            format!("classic_address: {}", self.classic_address),
-        ];
+            format!("classic_address: {}", self.classic_address)];
 
         string_list.join("-")
     }

--- a/tests/common/constants.rs
+++ b/tests/common/constants.rs
@@ -1,6 +1,6 @@
-pub const ECHO_WS_SERVER: &'static str = "ws://ws.vi-server.org/mirror";
-pub const ECHO_WSS_SERVER: &'static str = "wss://ws.vi-server.org/mirror";
+pub const ECHO_WS_SERVER: &str = "ws://ws.vi-server.org/mirror";
+pub const ECHO_WSS_SERVER: &str = "wss://ws.vi-server.org/mirror";
 
 // pub const XRPL_TEST_NET: &'static str = "ws://s2.livenet.ripple.com/";
-pub const XRPL_WSS_TEST_NET: &'static str = "wss://testnet.xrpl-labs.com/";
-pub const XRPL_WS_TEST_NET: &'static str = "wss://s.altnet.rippletest.net:51233/";
+pub const XRPL_WSS_TEST_NET: &str = "wss://testnet.xrpl-labs.com/";
+pub const XRPL_WS_TEST_NET: &str = "wss://s.altnet.rippletest.net:51233/";

--- a/tests/integration/clients/mod.rs
+++ b/tests/integration/clients/mod.rs
@@ -73,3 +73,20 @@ pub async fn test_embedded_websocket_request() -> Result<()> {
     let _res = websocket.request::<FeeResult, _>(fee).await?;
     Ok(())
 }
+
+pub async fn test_json_rpc() -> Result<()> {
+    use xrpl::{
+        asynch::clients::AsyncJsonRpcClient, models::requests::Fee, models::results::FeeResult,
+    };
+    let tcp_stream = tokio::net::TcpStream::connect("ws.vi-server.org:80")
+        .await
+        .unwrap();
+    let mut client = AsyncJsonRpcClient::new(
+        "https://s.altnet.rippletest.net:51234".into(),
+        &tcp_stream,
+        &reqwest::Client::new(),
+    );
+    let server_state = client.request::<FeeResult, _>(Fee::new(None)).await?;
+    assert!(server_state.result.state.is_some());
+    Ok(())
+}

--- a/tests/integration/clients/mod.rs
+++ b/tests/integration/clients/mod.rs
@@ -74,19 +74,19 @@ pub async fn test_embedded_websocket_request() -> Result<()> {
     Ok(())
 }
 
-pub async fn test_json_rpc() -> Result<()> {
+#[cfg(feature = "json-rpc-std")]
+pub async fn test_json_rpc_std() -> Result<()> {
     use xrpl::{
-        asynch::clients::AsyncJsonRpcClient, models::requests::Fee, models::results::FeeResult,
+        asynch::clients::{AsyncClient, AsyncJsonRpcClient, SingleExecutorMutex},
+        models::requests::Fee,
+        models::results::FeeResult,
     };
-    let tcp_stream = tokio::net::TcpStream::connect("ws.vi-server.org:80")
+    let client: AsyncJsonRpcClient<SingleExecutorMutex> =
+        AsyncJsonRpcClient::new("https://s1.ripple.com:51234/".parse().unwrap());
+    let fee_result = client
+        .request::<FeeResult, _>(Fee::new(None))
         .await
         .unwrap();
-    let mut client = AsyncJsonRpcClient::new(
-        "https://s.altnet.rippletest.net:51234".into(),
-        &tcp_stream,
-        &reqwest::Client::new(),
-    );
-    let server_state = client.request::<FeeResult, _>(Fee::new(None)).await?;
-    assert!(server_state.result.state.is_some());
+    assert!(fee_result.result.is_some());
     Ok(())
 }

--- a/tests/integration/clients/mod.rs
+++ b/tests/integration/clients/mod.rs
@@ -74,7 +74,7 @@ pub async fn test_embedded_websocket_request() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "json-rpc-std")]
+#[cfg(all(feature = "json-rpc-std", not(feature = "json-rpc")))]
 pub async fn test_json_rpc_std() -> Result<()> {
     use xrpl::{
         asynch::clients::{AsyncClient, AsyncJsonRpcClient, SingleExecutorMutex},

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -27,10 +27,10 @@ async fn test_asynch_clients_request() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "json-rpc-std")]
+#[cfg(all(feature = "json-rpc-std", not(feature = "json-rpc")))]
 #[tokio::test]
 async fn test_asynch_clients_json_rpc() -> Result<()> {
-    #[cfg(feature = "json-rpc-std")]
+    #[cfg(all(feature = "json-rpc-std", not(feature = "json-rpc")))]
     return integration::clients::test_json_rpc_std().await;
     #[allow(unreachable_code)]
     Ok(())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -27,11 +27,11 @@ async fn test_asynch_clients_request() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "json-rpc")]
+#[cfg(feature = "json-rpc-std")]
 #[tokio::test]
 async fn test_asynch_clients_json_rpc() -> Result<()> {
-    #[cfg(feature = "json-rpc")]
-    return integration::clients::test_json_rpc().await;
+    #[cfg(feature = "json-rpc-std")]
+    return integration::clients::test_json_rpc_std().await;
     #[allow(unreachable_code)]
     Ok(())
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -26,3 +26,12 @@ async fn test_asynch_clients_request() -> Result<()> {
     #[allow(unreachable_code)]
     Ok(())
 }
+
+#[cfg(feature = "json-rpc")]
+#[tokio::test]
+async fn test_asynch_clients_json_rpc() -> Result<()> {
+    #[cfg(feature = "json-rpc")]
+    return integration::clients::test_json_rpc().await;
+    #[allow(unreachable_code)]
+    Ok(())
+}


### PR DESCRIPTION
## High Level Overview of Change

This PR add clients for JsonRPC requests. For `no_std` we use `reqwless` and for `std` we use `reqwest`.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

#17 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

There is a test for requesting the current fees with the std client.