### PR TITLE
Auto fill transaction

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -4,9 +4,10 @@ set -e
 echo 'Running all pre-commit checks:'
 cargo fmt
 cargo test --no-default-features --features core,models,utils
-cargo test --no-default-features --features core,models,utils,embedded-ws
-cargo test --no-default-features --features core,models,utils,tungstenite
+cargo test --no-default-features --features std,models,utils,websocket,websocket-codec
+cargo test --no-default-features --features core,models,utils,websocket-std
 cargo test --no-default-features --features core,models,utils,json-rpc-std
+cargo test --no-default-features --features websocket-std,helpers
 cargo test --all-features
 cargo clippy --fix --allow-staged
 cargo doc --no-deps

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -37,4 +37,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features core,models,websocket
+          args: --no-default-features --features std,models,websocket,websocket-codec
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features websocket-std,helpers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,12 +95,23 @@ name = "benchmarks"
 harness = false
 
 [features]
-default = ["std", "core", "models", "utils", "websocket-std"]
+default = ["std", "core", "models", "utils", "helpers", "websocket-std"]
 models = ["core", "transactions", "requests", "ledger", "results"]
 transactions = ["core", "amounts", "currencies"]
 requests = ["core", "amounts", "currencies"]
 results = ["core", "amounts", "currencies"]
 ledger = ["core", "amounts", "currencies"]
+helpers = ["account-helpers", "ledger-helpers", "transaction-helpers"]
+account-helpers = ["amounts", "currencies", "requests", "results"]
+ledger-helpers = ["amounts", "currencies", "requests", "results"]
+transaction-helpers = [
+    "amounts",
+    "currencies",
+    "requests",
+    "results",
+    "transactions",
+    "ledger",
+]
 amounts = ["core"]
 currencies = ["core"]
 json-rpc = ["url", "reqwless", "embedded-nal-async"]

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/bin/wallet/generate_wallet.rs"
 required-features = []
 
 [[bin]]
-name = "tungstenite"
+name = "websocket-std"
 path = "src/bin/tokio/net/tungstenite.rs"
 required-features = ["tokio"]
 

--- a/src/asynch/account/mod.rs
+++ b/src/asynch/account/mod.rs
@@ -1,0 +1,52 @@
+use alloc::borrow::Cow;
+use anyhow::Result;
+
+use crate::{
+    core::addresscodec::{is_valid_xaddress, xaddress_to_classic_address},
+    models::{ledger::AccountRoot, requests::AccountInfo, results},
+    Err,
+};
+
+use super::clients::AsyncClient;
+
+pub async fn get_next_valid_seq_number(
+    address: Cow<'_, str>,
+    client: &impl AsyncClient,
+    ledger_index: Option<Cow<'_, str>>,
+) -> Result<u32> {
+    let account_info =
+        get_account_root(address, client, ledger_index.unwrap_or("current".into())).await?;
+    Ok(account_info.sequence)
+}
+
+pub async fn get_account_root<'a>(
+    address: Cow<'a, str>,
+    client: &impl AsyncClient,
+    ledger_index: Cow<'a, str>,
+) -> Result<AccountRoot<'a>> {
+    let mut classic_address = address;
+    if is_valid_xaddress(&classic_address) {
+        classic_address = match xaddress_to_classic_address(&classic_address) {
+            Ok(addr) => addr.0.into(),
+            Err(e) => return Err!(e),
+        };
+    }
+    let account_info = client
+        .request(
+            AccountInfo::new(
+                None,
+                classic_address,
+                None,
+                Some(ledger_index),
+                None,
+                None,
+                None,
+            )
+            .into(),
+        )
+        .await?;
+
+    Ok(account_info
+        .try_into_result::<results::AccountInfo<'_>>()?
+        .account_data)
+}

--- a/src/asynch/clients/async_client.rs
+++ b/src/asynch/clients/async_client.rs
@@ -1,11 +1,27 @@
-use super::client::Client;
-use crate::models::{requests::XRPLRequest, results::XRPLResponse};
+use super::{client::Client, CommonFields};
+use crate::models::{
+    requests::{ServerState, XRPLRequest},
+    results::{ServerState as ServerStateResult, XRPLResponse},
+};
 use anyhow::Result;
 
 #[allow(async_fn_in_trait)]
 pub trait AsyncClient: Client {
     async fn request<'a: 'b, 'b>(&self, request: XRPLRequest<'a>) -> Result<XRPLResponse<'b>> {
         self.request_impl(request).await
+    }
+
+    async fn get_common_fields(&self) -> Result<CommonFields<'_>> {
+        let server_state = self.request(ServerState::new(None).into()).await?;
+        let state = server_state
+            .try_into_result::<ServerStateResult<'_>>()?
+            .state;
+        let common_fields = CommonFields {
+            network_id: state.network_id,
+            build_version: Some(state.build_version),
+        };
+
+        Ok(common_fields)
     }
 }
 

--- a/src/asynch/clients/mod.rs
+++ b/src/asynch/clients/mod.rs
@@ -5,6 +5,7 @@ pub mod json_rpc;
 #[cfg(any(feature = "websocket-std", feature = "websocket"))]
 pub mod websocket;
 
+use alloc::borrow::Cow;
 use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex};
 pub type MultiExecutorMutex = CriticalSectionRawMutex;
 pub type SingleExecutorMutex = NoopRawMutex;
@@ -13,5 +14,12 @@ pub use async_client::*;
 pub use client::*;
 #[cfg(any(feature = "json-rpc-std", feature = "json-rpc"))]
 pub use json_rpc::*;
+use serde::{Deserialize, Serialize};
 #[cfg(any(feature = "websocket-std", feature = "websocket"))]
 pub use websocket::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommonFields<'a> {
+    pub build_version: Option<Cow<'a, str>>,
+    pub network_id: Option<u32>,
+}

--- a/src/asynch/clients/websocket/mod.rs
+++ b/src/asynch/clients/websocket/mod.rs
@@ -19,7 +19,7 @@ use websocket_base::MessageHandler;
 
 #[cfg(all(feature = "websocket", not(feature = "websocket-std")))]
 mod _no_std;
-#[cfg(feature = "websocket-codec")]
+#[cfg(all(feature = "websocket-codec", feature = "std"))]
 pub mod codec;
 mod exceptions;
 pub use exceptions::XRPLWebsocketException;

--- a/src/asynch/ledger/mod.rs
+++ b/src/asynch/ledger/mod.rs
@@ -1,0 +1,71 @@
+use core::{cmp::min, convert::TryInto};
+
+use alloc::string::ToString;
+use anyhow::Result;
+
+use crate::models::{
+    amount::XRPAmount,
+    requests::{Fee, Ledger},
+    results::{Drops, Fee as FeeResult, Ledger as LedgerResult},
+};
+
+use super::clients::AsyncClient;
+
+pub async fn get_latest_validated_ledger_sequence(client: &impl AsyncClient) -> Result<u32> {
+    let ledger_response = client
+        .request(
+            Ledger::new(
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some("validated".into()),
+                None,
+                None,
+                None,
+            )
+            .into(),
+        )
+        .await?;
+
+    Ok(ledger_response
+        .try_into_result::<LedgerResult<'_>>()?
+        .ledger_index)
+}
+
+pub enum FeeType {
+    Open,
+    Minimum,
+    Dynamic,
+}
+
+pub async fn get_fee(
+    client: &impl AsyncClient,
+    max_fee: Option<u32>,
+    fee_type: Option<FeeType>,
+) -> Result<XRPAmount<'_>> {
+    let fee_request = Fee::new(None);
+    match client.request(fee_request.into()).await {
+        Ok(response) => {
+            let drops = response.try_into_result::<FeeResult<'_>>()?.drops;
+            let fee = match_fee_type(fee_type, drops)?;
+
+            if let Some(max_fee) = max_fee {
+                Ok(XRPAmount::from(min(max_fee, fee).to_string()))
+            } else {
+                Ok(XRPAmount::from(fee.to_string()))
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn match_fee_type(fee_type: Option<FeeType>, drops: Drops<'_>) -> Result<u32> {
+    match fee_type {
+        None | Some(FeeType::Open) => Ok(drops.open_ledger_fee.try_into()?),
+        Some(FeeType::Minimum) => Ok(drops.minimum_fee.try_into()?),
+        Some(FeeType::Dynamic) => unimplemented!("Dynamic fee calculation not yet implemented"),
+    }
+}

--- a/src/asynch/mod.rs
+++ b/src/asynch/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "account-helpers")]
+pub mod account;
 #[cfg(any(
     feature = "websocket-std",
     feature = "websocket",
@@ -5,3 +7,7 @@
     feature = "json-rpc"
 ))]
 pub mod clients;
+#[cfg(feature = "ledger-helpers")]
+pub mod ledger;
+#[cfg(feature = "transaction-helpers")]
+pub mod transaction;

--- a/src/asynch/transaction/exceptions.rs
+++ b/src/asynch/transaction/exceptions.rs
@@ -1,0 +1,16 @@
+use core::num::ParseIntError;
+
+use alloc::borrow::Cow;
+use thiserror_no_std::Error;
+
+use crate::models::amount::XRPAmount;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum XRPLTransactionException<'a> {
+    #[error("Fee of {0:?} Drops is much higher than a typical XRP transaction fee. This may be a mistake. If intentional, please use `check_fee = false`")]
+    FeeUnusuallyHigh(XRPAmount<'a>),
+    #[error("Unable to parse rippled version: {0}")]
+    ParseRippledVersionError(ParseIntError),
+    #[error("Invalid rippled version: {0}")]
+    InvalidRippledVersion(Cow<'a, str>),
+}

--- a/src/asynch/transaction/mod.rs
+++ b/src/asynch/transaction/mod.rs
@@ -1,0 +1,292 @@
+use super::account::get_next_valid_seq_number;
+use super::clients::AsyncClient;
+use super::clients::CommonFields;
+use super::ledger::get_fee;
+use super::ledger::get_latest_validated_ledger_sequence;
+use crate::models::amount::XRPAmount;
+use crate::models::exceptions::XRPLModelException;
+use crate::models::requests::ServerState;
+use crate::models::results::ServerState as ServerStateResult;
+use crate::models::transactions::Transaction;
+use crate::models::transactions::TransactionType;
+use crate::models::Model;
+use crate::Err;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use anyhow::Result;
+use core::convert::TryInto;
+use core::fmt::Debug;
+use exceptions::XRPLTransactionException;
+use rust_decimal::Decimal;
+use serde::Serialize;
+use strum::IntoEnumIterator;
+
+pub mod exceptions;
+
+const OWNER_RESERVE: &str = "2000000"; // 2 XRP
+const RESTRICTED_NETWORKS: u16 = 1024;
+const REQUIRED_NETWORKID_VERSION: &str = "1.11.0";
+const LEDGER_OFFSET: u8 = 20;
+
+pub async fn autofill<'a, 'b, F, T>(
+    transaction: &mut T,
+    client: &'a impl AsyncClient,
+    signers_count: Option<u8>,
+) -> Result<()>
+where
+    'a: 'b,
+    T: Transaction<'b, F> + Model + Clone,
+    F: IntoEnumIterator + Serialize + Debug + PartialEq,
+{
+    let txn = transaction.clone();
+    let txn_common_fields = transaction.get_mut_common_fields();
+    let common_fields = client.get_common_fields().await?;
+    if txn_common_fields.network_id.is_none() && txn_needs_network_id(common_fields.clone())? {
+        txn_common_fields.network_id = common_fields.network_id;
+    }
+    if txn_common_fields.sequence.is_none() {
+        txn_common_fields.sequence =
+            Some(get_next_valid_seq_number(txn_common_fields.account.clone(), client, None).await?);
+    }
+    if txn_common_fields.fee.is_none() {
+        txn_common_fields.fee =
+            Some(calculate_fee_per_transaction_type(txn, Some(client), signers_count).await?);
+    }
+    if txn_common_fields.last_ledger_sequence.is_none() {
+        let ledger_sequence = get_latest_validated_ledger_sequence(client).await?;
+        txn_common_fields.last_ledger_sequence = Some(ledger_sequence + LEDGER_OFFSET as u32);
+    }
+
+    Ok(())
+}
+
+pub async fn calculate_fee_per_transaction_type<'a, 'b, T, F>(
+    transaction: T,
+    client: Option<&'a impl AsyncClient>,
+    signers_count: Option<u8>,
+) -> Result<XRPAmount<'_>>
+where
+    'a: 'b,
+    T: Transaction<'b, F>,
+    F: IntoEnumIterator + Serialize + Debug + PartialEq,
+{
+    let mut net_fee = XRPAmount::from("10");
+    let base_fee;
+    if let Some(client) = client {
+        net_fee = get_fee(client, None, None).await?;
+        base_fee = match transaction.get_transaction_type() {
+            TransactionType::EscrowFinish => calculate_base_fee_for_escrow_finish(
+                net_fee.clone(),
+                transaction
+                    .get_field_value("fulfillment")?
+                    .map(|fulfillment| fulfillment.into()),
+            )?,
+            // TODO: same for TransactionType::AMMCreate
+            TransactionType::AccountDelete => get_owner_reserve_from_response(client).await?,
+            _ => net_fee.clone(),
+        };
+    } else {
+        base_fee = match transaction.get_transaction_type() {
+            TransactionType::EscrowFinish => calculate_base_fee_for_escrow_finish(
+                net_fee.clone(),
+                transaction
+                    .get_field_value("fulfillment")?
+                    .map(|fulfillment| fulfillment.into()),
+            )?,
+            // TODO: same for TransactionType::AMMCreate
+            TransactionType::AccountDelete => XRPAmount::from(OWNER_RESERVE),
+            _ => net_fee.clone(),
+        };
+    }
+    let mut base_fee_decimal: Decimal = base_fee.try_into()?;
+    if let Some(signers_count) = signers_count {
+        let net_fee_decimal: Decimal = net_fee.try_into()?;
+        let signer_count_fee_decimal: Decimal = (1 + signers_count).into();
+        base_fee_decimal += &(net_fee_decimal * signer_count_fee_decimal);
+    }
+
+    Ok(base_fee_decimal.ceil().into())
+}
+
+async fn get_owner_reserve_from_response(client: &impl AsyncClient) -> Result<XRPAmount<'_>> {
+    let owner_reserve_response = client.request(ServerState::new(None).into()).await?;
+    match owner_reserve_response
+        .try_into_result::<ServerStateResult<'_>>()?
+        .state
+        .validated_ledger
+    {
+        Some(validated_ledger) => Ok(validated_ledger.reserve_base),
+        None => Err!(XRPLModelException::MissingField("validated_ledger")),
+    }
+}
+
+fn calculate_base_fee_for_escrow_finish<'a>(
+    net_fee: XRPAmount<'a>,
+    fulfillment: Option<Cow<str>>,
+) -> Result<XRPAmount<'a>> {
+    if let Some(fulfillment) = fulfillment {
+        calculate_based_on_fulfillment(fulfillment, net_fee)
+    } else {
+        Ok(net_fee)
+    }
+}
+
+fn calculate_based_on_fulfillment<'a>(
+    fulfillment: Cow<str>,
+    net_fee: XRPAmount<'_>,
+) -> Result<XRPAmount<'a>> {
+    let fulfillment_bytes: Vec<u8> = fulfillment.chars().map(|c| c as u8).collect();
+    let net_fee_f64: f64 = net_fee.try_into()?;
+    let base_fee_string =
+        (net_fee_f64 * (33.0 + (fulfillment_bytes.len() as f64 / 16.0))).to_string();
+    let base_fee: XRPAmount = base_fee_string.into();
+    let base_fee_decimal: Decimal = base_fee.try_into()?;
+
+    Ok(base_fee_decimal.ceil().into())
+}
+
+fn txn_needs_network_id(common_fields: CommonFields<'_>) -> Result<bool> {
+    let is_higher_restricted_networks = if let Some(network_id) = common_fields.network_id {
+        network_id > RESTRICTED_NETWORKS as u32
+    } else {
+        false
+    };
+    if let Some(build_version) = common_fields.build_version {
+        match is_not_later_rippled_version(REQUIRED_NETWORKID_VERSION.into(), build_version.into())
+        {
+            Ok(is_not_later_rippled_version) => {
+                Ok(is_higher_restricted_networks && is_not_later_rippled_version)
+            }
+            Err(e) => Err!(e),
+        }
+    } else {
+        Ok(false)
+    }
+}
+
+fn is_not_later_rippled_version<'a>(
+    source: String,
+    target: String,
+) -> Result<bool, XRPLTransactionException<'a>> {
+    if source == target {
+        Ok(true)
+    } else {
+        let source_decomp = source
+            .split('.')
+            .map(|i| i.to_string())
+            .collect::<Vec<String>>();
+        let target_decomp = target
+            .split('.')
+            .map(|i| i.to_string())
+            .collect::<Vec<String>>();
+        let (source_major, source_minor) = (
+            source_decomp[0]
+                .parse::<u8>()
+                .map_err(XRPLTransactionException::ParseRippledVersionError)?,
+            source_decomp[1]
+                .parse::<u8>()
+                .map_err(XRPLTransactionException::ParseRippledVersionError)?,
+        );
+        let (target_major, target_minor) = (
+            target_decomp[0]
+                .parse::<u8>()
+                .map_err(XRPLTransactionException::ParseRippledVersionError)?,
+            target_decomp[1]
+                .parse::<u8>()
+                .map_err(XRPLTransactionException::ParseRippledVersionError)?,
+        );
+        if source_major != target_major {
+            Ok(source_major < target_major)
+        } else if source_minor != target_minor {
+            Ok(source_minor < target_minor)
+        } else {
+            let source_patch = source_decomp[2]
+                .split('-')
+                .map(|i| i.to_string())
+                .collect::<Vec<String>>();
+            let target_patch = target_decomp[2]
+                .split('-')
+                .map(|i| i.to_string())
+                .collect::<Vec<String>>();
+            let source_patch_version = source_patch[0]
+                .parse::<u8>()
+                .map_err(XRPLTransactionException::ParseRippledVersionError)?;
+            let target_patch_version = target_patch[0]
+                .parse::<u8>()
+                .map_err(XRPLTransactionException::ParseRippledVersionError)?;
+            if source_patch_version != target_patch_version {
+                Ok(source_patch_version < target_patch_version)
+            } else if source_patch.len() != target_patch.len() {
+                Ok(source_patch.len() < target_patch.len())
+            } else if source_patch.len() == 2 {
+                if source_patch[1].chars().next().ok_or(
+                    XRPLTransactionException::InvalidRippledVersion("source patch version".into()),
+                )? != target_patch[1].chars().next().ok_or(
+                    XRPLTransactionException::InvalidRippledVersion("target patch version".into()),
+                )? {
+                    Ok(source_patch[1] < target_patch[1])
+                } else if source_patch[1].starts_with('b') {
+                    Ok(&source_patch[1][1..] < &target_patch[1][1..])
+                } else {
+                    Ok(&source_patch[1][2..] < &target_patch[1][2..])
+                }
+            } else {
+                Ok(false)
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "websocket-std", feature = "std", not(feature = "websocket")))]
+#[cfg(test)]
+mod test_autofill {
+    use super::autofill;
+    use crate::{
+        asynch::clients::{AsyncWebsocketClient, SingleExecutorMutex},
+        models::{
+            amount::{IssuedCurrencyAmount, XRPAmount},
+            transactions::{OfferCreate, Transaction},
+        },
+    };
+    use anyhow::Result;
+
+    #[tokio::test]
+    async fn test_autofill_txn() -> Result<()> {
+        let mut txn = OfferCreate::new(
+            "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq".into(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            XRPAmount::from("1000000").into(),
+            IssuedCurrencyAmount::new(
+                "USD".into(),
+                "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq".into(),
+                "0.3".into(),
+            )
+            .into(),
+            None,
+            None,
+        );
+        let client = AsyncWebsocketClient::<SingleExecutorMutex, _>::open(
+            "wss://testnet.xrpl-labs.com/".parse().unwrap(),
+        )
+        .await
+        .unwrap();
+        autofill(&mut txn, &client, None).await?;
+
+        assert!(txn.get_common_fields().network_id.is_none());
+        assert!(txn.get_common_fields().sequence.is_some());
+        assert!(txn.get_common_fields().fee.is_some());
+        assert!(txn.get_common_fields().last_ledger_sequence.is_some());
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,14 @@ pub mod constants;
 #[cfg(feature = "core")]
 pub mod core;
 pub mod macros;
-#[cfg(feature = "models")]
+#[cfg(any(
+    feature = "amounts",
+    feature = "currencies",
+    feature = "ledger",
+    feature = "requests",
+    feature = "results",
+    feature = "transactions"
+))]
 pub mod models;
 #[cfg(feature = "utils")]
 pub mod utils;

--- a/src/models/amount/exceptions.rs
+++ b/src/models/amount/exceptions.rs
@@ -1,9 +1,17 @@
+use core::num::ParseFloatError;
+
 use thiserror_no_std::Error;
 
-#[derive(Debug, Clone, PartialEq, Error)]
+#[derive(Debug, Error)]
 pub enum XRPLAmountException {
     #[error("Unable to convert amount `value` into `Decimal`.")]
     ToDecimalError(#[from] rust_decimal::Error),
+    #[error("Unable to convert amount float.")]
+    ToFloatError(#[from] ParseFloatError),
+    #[error("Unable to convert amount integer.")]
+    ToIntError(#[from] core::num::ParseIntError),
+    #[error("{0:?}")]
+    FromSerdeError(#[from] serde_json::Error),
 }
 
 #[cfg(feature = "std")]

--- a/src/models/amount/issued_currency_amount.rs
+++ b/src/models/amount/issued_currency_amount.rs
@@ -1,5 +1,5 @@
-use crate::models::amount::exceptions::XRPLAmountException;
 use crate::models::Model;
+use crate::{models::amount::exceptions::XRPLAmountException, Err};
 use alloc::borrow::Cow;
 use core::convert::TryInto;
 use core::str::FromStr;
@@ -26,12 +26,24 @@ impl<'a> IssuedCurrencyAmount<'a> {
 }
 
 impl<'a> TryInto<Decimal> for IssuedCurrencyAmount<'a> {
-    type Error = XRPLAmountException;
+    type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Decimal, Self::Error> {
         match Decimal::from_str(&self.value) {
             Ok(decimal) => Ok(decimal),
-            Err(decimal_error) => Err(XRPLAmountException::ToDecimalError(decimal_error)),
+            Err(decimal_error) => Err!(XRPLAmountException::ToDecimalError(decimal_error)),
         }
+    }
+}
+
+impl<'a> PartialOrd for IssuedCurrencyAmount<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl<'a> Ord for IssuedCurrencyAmount<'a> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.value.cmp(&other.value)
     }
 }

--- a/src/models/amount/mod.rs
+++ b/src/models/amount/mod.rs
@@ -7,7 +7,6 @@ pub use issued_currency_amount::*;
 use rust_decimal::Decimal;
 pub use xrp_amount::*;
 
-use crate::models::amount::exceptions::XRPLAmountException;
 use crate::models::Model;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
@@ -20,7 +19,7 @@ pub enum Amount<'a> {
 }
 
 impl<'a> TryInto<Decimal> for Amount<'a> {
-    type Error = XRPLAmountException;
+    type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Decimal, Self::Error> {
         match self {

--- a/src/models/amount/xrp_amount.rs
+++ b/src/models/amount/xrp_amount.rs
@@ -1,15 +1,32 @@
-use crate::models::amount::exceptions::XRPLAmountException;
 use crate::models::Model;
-use alloc::borrow::Cow;
-use core::convert::TryInto;
+use crate::{models::amount::exceptions::XRPLAmountException, Err};
+use alloc::{
+    borrow::Cow,
+    string::{String, ToString},
+};
+use anyhow::Result;
+use core::convert::{TryFrom, TryInto};
 use core::str::FromStr;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+/// Represents an amount of XRP in Drops.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Default)]
 pub struct XRPAmount<'a>(pub Cow<'a, str>);
 
 impl<'a> Model for XRPAmount<'a> {}
+
+// implement Deserializing from Cow<str>, &str, String, Decimal, f64, u32, and Value
+impl<'de, 'a> Deserialize<'de> for XRPAmount<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<XRPAmount<'a>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let amount_string = Value::deserialize(deserializer)?;
+        XRPAmount::try_from(amount_string).map_err(serde::de::Error::custom)
+    }
+}
 
 impl<'a> From<Cow<'a, str>> for XRPAmount<'a> {
     fn from(value: Cow<'a, str>) -> Self {
@@ -23,13 +40,85 @@ impl<'a> From<&'a str> for XRPAmount<'a> {
     }
 }
 
+impl<'a> From<String> for XRPAmount<'a> {
+    fn from(value: String) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<'a> From<Decimal> for XRPAmount<'a> {
+    fn from(value: Decimal) -> Self {
+        Self(value.to_string().into())
+    }
+}
+
+impl<'a> From<f64> for XRPAmount<'a> {
+    fn from(value: f64) -> Self {
+        Self(value.to_string().into())
+    }
+}
+
+impl<'a> From<u32> for XRPAmount<'a> {
+    fn from(value: u32) -> Self {
+        Self(value.to_string().into())
+    }
+}
+
+impl<'a> TryFrom<Value> for XRPAmount<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match serde_json::to_string(&value) {
+            Ok(amount_string) => {
+                let amount_string = amount_string.clone().replace("\"", "");
+                Ok(Self(amount_string.into()))
+            }
+            Err(serde_error) => Err!(XRPLAmountException::FromSerdeError(serde_error)),
+        }
+    }
+}
+
+impl<'a> TryInto<f64> for XRPAmount<'a> {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<f64, Self::Error> {
+        match self.0.parse::<f64>() {
+            Ok(f64_value) => Ok(f64_value),
+            Err(parse_error) => Err!(XRPLAmountException::ToFloatError(parse_error)),
+        }
+    }
+}
+
+impl<'a> TryInto<u32> for XRPAmount<'a> {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<u32, Self::Error> {
+        match self.0.parse::<u32>() {
+            Ok(u32_value) => Ok(u32_value),
+            Err(parse_error) => Err!(XRPLAmountException::ToIntError(parse_error)),
+        }
+    }
+}
+
 impl<'a> TryInto<Decimal> for XRPAmount<'a> {
-    type Error = XRPLAmountException;
+    type Error = anyhow::Error;
 
     fn try_into(self) -> Result<Decimal, Self::Error> {
         match Decimal::from_str(&self.0) {
             Ok(decimal) => Ok(decimal),
-            Err(decimal_error) => Err(XRPLAmountException::ToDecimalError(decimal_error)),
+            Err(decimal_error) => Err!(XRPLAmountException::ToDecimalError(decimal_error)),
         }
+    }
+}
+
+impl<'a> PartialOrd for XRPAmount<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.0.cmp(&other.0))
+    }
+}
+
+impl<'a> Ord for XRPAmount<'a> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.cmp(&other.0)
     }
 }

--- a/src/models/exceptions.rs
+++ b/src/models/exceptions.rs
@@ -4,15 +4,18 @@ use crate::models::requests::XRPLRequestException;
 use crate::models::transactions::XRPLTransactionException;
 use alloc::string::String;
 use serde::{Deserialize, Serialize};
-use strum_macros::Display;
 use thiserror_no_std::Error;
 
-#[derive(Debug, PartialEq, Display)]
-#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Error)]
 pub enum XRPLModelException<'a> {
+    #[error("Issued Currency can not be XRP")]
     InvalidICCannotBeXRP,
+    #[error("Transaction Model Error: {0}")]
     XRPLTransactionError(XRPLTransactionException<'a>),
+    #[error("Request Model Error: {0}")]
     XRPLRequestError(XRPLRequestException<'a>),
+    #[error("Missing Field: {0}")]
+    MissingField(&'a str),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]

--- a/src/models/results/account_info.rs
+++ b/src/models/results/account_info.rs
@@ -1,0 +1,30 @@
+use core::convert::TryFrom;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::{ledger::AccountRoot, results::exceptions::XRPLResultException},
+    Err,
+};
+
+use super::XRPLResult;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountInfo<'a> {
+    pub account_data: AccountRoot<'a>,
+}
+
+impl<'a> TryFrom<XRPLResult<'a>> for AccountInfo<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(result: XRPLResult<'a>) -> Result<Self> {
+        match result {
+            XRPLResult::AccountInfo(account_info) => Ok(account_info),
+            res => Err!(XRPLResultException::UnexpectedResultType(
+                "AccountInfo".to_string(),
+                res.get_name()
+            )),
+        }
+    }
+}

--- a/src/models/results/exceptions.rs
+++ b/src/models/results/exceptions.rs
@@ -1,0 +1,12 @@
+use alloc::string::String;
+use thiserror_no_std::Error;
+
+#[derive(Debug, Error)]
+pub enum XRPLResultException {
+    #[error("Response error: {0}")]
+    ResponseError(String),
+    #[error("Expected result or error in the response.")]
+    ExpectedResultOrError,
+    #[error("Unexpected result type (expected {0:?}, got {1:?}).")]
+    UnexpectedResultType(String, String),
+}

--- a/src/models/results/fee.rs
+++ b/src/models/results/fee.rs
@@ -1,6 +1,14 @@
+use core::convert::TryFrom;
+
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::models::amount::XRPAmount;
+use crate::{
+    models::{amount::XRPAmount, results::exceptions::XRPLResultException},
+    Err,
+};
+
+use super::XRPLResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Fee<'a> {
@@ -13,4 +21,18 @@ pub struct Drops<'a> {
     pub median_fee: XRPAmount<'a>,
     pub minimum_fee: XRPAmount<'a>,
     pub open_ledger_fee: XRPAmount<'a>,
+}
+
+impl<'a> TryFrom<XRPLResult<'a>> for Fee<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(result: XRPLResult<'a>) -> Result<Self> {
+        match result {
+            XRPLResult::Fee(fee) => Ok(fee),
+            res => Err!(XRPLResultException::UnexpectedResultType(
+                "Fee".to_string(),
+                res.get_name()
+            )),
+        }
+    }
 }

--- a/src/models/results/ledger.rs
+++ b/src/models/results/ledger.rs
@@ -1,0 +1,49 @@
+use core::convert::TryFrom;
+
+use alloc::{borrow::Cow, vec::Vec};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::{models::results::exceptions::XRPLResultException, Err};
+
+use super::XRPLResult;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Ledger<'a> {
+    pub ledger: LedgerInner<'a>,
+    pub ledger_hash: Cow<'a, str>,
+    pub ledger_index: u32,
+    pub validated: Option<bool>,
+    pub queue_data: Option<Cow<'a, str>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LedgerInner<'a> {
+    pub account_hash: Cow<'a, str>,
+    pub close_flags: u32,
+    pub close_time: u32,
+    pub close_time_human: Option<Cow<'a, str>>,
+    pub close_time_resolution: u32,
+    pub closed: bool,
+    pub ledger_hash: Cow<'a, str>,
+    pub ledger_index: Cow<'a, str>,
+    pub parent_close_time: u32,
+    pub parent_hash: Cow<'a, str>,
+    pub total_coins: Cow<'a, str>,
+    pub transaction_hash: Cow<'a, str>,
+    pub transactions: Option<Vec<Cow<'a, str>>>,
+}
+
+impl<'a> TryFrom<XRPLResult<'a>> for Ledger<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(result: XRPLResult<'a>) -> Result<Self> {
+        match result {
+            XRPLResult::Ledger(ledger) => Ok(ledger),
+            res => Err!(XRPLResultException::UnexpectedResultType(
+                "Ledger".to_string(),
+                res.get_name()
+            )),
+        }
+    }
+}

--- a/src/models/results/server_state.rs
+++ b/src/models/results/server_state.rs
@@ -1,0 +1,48 @@
+use core::convert::TryFrom;
+
+use alloc::borrow::Cow;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::{amount::XRPAmount, results::exceptions::XRPLResultException},
+    Err,
+};
+
+use super::XRPLResult;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerState<'a> {
+    pub state: State<'a>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct State<'a> {
+    pub build_version: Cow<'a, str>,
+    pub network_id: Option<u32>,
+    pub validated_ledger: Option<ValidatedLedger<'a>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidatedLedger<'a> {
+    pub base_fee: XRPAmount<'a>,
+    pub close_time: u32,
+    pub hash: Cow<'a, str>,
+    pub reserve_base: XRPAmount<'a>,
+    pub reserve_inc: XRPAmount<'a>,
+    pub seq: u32,
+}
+
+impl<'a> TryFrom<XRPLResult<'a>> for ServerState<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(result: XRPLResult<'a>) -> Result<Self> {
+        match result {
+            XRPLResult::ServerState(server_state) => Ok(server_state),
+            res => Err!(XRPLResultException::UnexpectedResultType(
+                "ServerState".to_string(),
+                res.get_name()
+            )),
+        }
+    }
+}

--- a/src/models/transactions/account_delete.rs
+++ b/src/models/transactions/account_delete.rs
@@ -46,9 +46,17 @@ pub struct AccountDelete<'a> {
 
 impl<'a> Model for AccountDelete<'a> {}
 
-impl<'a> Transaction<NoFlags> for AccountDelete<'a> {
+impl<'a> Transaction<'a, NoFlags> for AccountDelete<'a> {
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -79,6 +87,9 @@ impl<'a> AccountDelete<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             destination,
             destination_tag,

--- a/src/models/transactions/account_set.rs
+++ b/src/models/transactions/account_set.rs
@@ -141,13 +141,21 @@ impl<'a: 'static> Model for AccountSet<'a> {
     }
 }
 
-impl<'a> Transaction<AccountSetFlag> for AccountSet<'a> {
+impl<'a> Transaction<'a, AccountSetFlag> for AccountSet<'a> {
     fn has_flag(&self, flag: &AccountSetFlag) -> bool {
         self.common_fields.has_flag(flag)
     }
 
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, AccountSetFlag> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, AccountSetFlag> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -313,6 +321,9 @@ impl<'a> AccountSet<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             clear_flag,
             domain,

--- a/src/models/transactions/check_cancel.rs
+++ b/src/models/transactions/check_cancel.rs
@@ -41,9 +41,17 @@ pub struct CheckCancel<'a> {
 
 impl<'a> Model for CheckCancel<'a> {}
 
-impl<'a> Transaction<NoFlags> for CheckCancel<'a> {
+impl<'a> Transaction<'a, NoFlags> for CheckCancel<'a> {
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -73,6 +81,9 @@ impl<'a> CheckCancel<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             check_id,
         }

--- a/src/models/transactions/check_cash.rs
+++ b/src/models/transactions/check_cash.rs
@@ -56,9 +56,17 @@ impl<'a: 'static> Model for CheckCash<'a> {
     }
 }
 
-impl<'a> Transaction<NoFlags> for CheckCash<'a> {
+impl<'a> Transaction<'a, NoFlags> for CheckCash<'a> {
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -106,6 +114,9 @@ impl<'a> CheckCash<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             check_id,
             amount,

--- a/src/models/transactions/check_create.rs
+++ b/src/models/transactions/check_create.rs
@@ -52,9 +52,17 @@ pub struct CheckCreate<'a> {
 
 impl<'a> Model for CheckCreate<'a> {}
 
-impl<'a> Transaction<NoFlags> for CheckCreate<'a> {
+impl<'a> Transaction<'a, NoFlags> for CheckCreate<'a> {
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -88,6 +96,9 @@ impl<'a> CheckCreate<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             destination,
             send_max,

--- a/src/models/transactions/deposit_preauth.rs
+++ b/src/models/transactions/deposit_preauth.rs
@@ -47,9 +47,17 @@ impl<'a: 'static> Model for DepositPreauth<'a> {
     }
 }
 
-impl<'a> Transaction<NoFlags> for DepositPreauth<'a> {
+impl<'a> Transaction<'a, NoFlags> for DepositPreauth<'a> {
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -96,6 +104,9 @@ impl<'a> DepositPreauth<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             authorize,
             unauthorize,

--- a/src/models/transactions/escrow_cancel.rs
+++ b/src/models/transactions/escrow_cancel.rs
@@ -40,9 +40,17 @@ pub struct EscrowCancel<'a> {
 
 impl<'a> Model for EscrowCancel<'a> {}
 
-impl<'a> Transaction<NoFlags> for EscrowCancel<'a> {
+impl<'a> Transaction<'a, NoFlags> for EscrowCancel<'a> {
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -73,6 +81,9 @@ impl<'a> EscrowCancel<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             owner,
             offer_sequence,

--- a/src/models/transactions/escrow_create.rs
+++ b/src/models/transactions/escrow_create.rs
@@ -65,9 +65,17 @@ impl<'a: 'static> Model for EscrowCreate<'a> {
     }
 }
 
-impl<'a> Transaction<NoFlags> for EscrowCreate<'a> {
+impl<'a> Transaction<'a, NoFlags> for EscrowCreate<'a> {
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -122,6 +130,9 @@ impl<'a> EscrowCreate<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             amount,
             destination,

--- a/src/models/transactions/escrow_finish.rs
+++ b/src/models/transactions/escrow_finish.rs
@@ -56,9 +56,17 @@ impl<'a: 'static> Model for EscrowFinish<'a> {
     }
 }
 
-impl<'a> Transaction<NoFlags> for EscrowFinish<'a> {
+impl<'a> Transaction<'a, NoFlags> for EscrowFinish<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -107,6 +115,9 @@ impl<'a> EscrowFinish<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             owner,
             offer_sequence,

--- a/src/models/transactions/nftoken_burn.rs
+++ b/src/models/transactions/nftoken_burn.rs
@@ -48,9 +48,17 @@ pub struct NFTokenBurn<'a> {
 
 impl<'a> Model for NFTokenBurn<'a> {}
 
-impl<'a> Transaction<NoFlags> for NFTokenBurn<'a> {
+impl<'a> Transaction<'a, NoFlags> for NFTokenBurn<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -81,6 +89,9 @@ impl<'a> NFTokenBurn<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             nftoken_id,
             owner,

--- a/src/models/transactions/nftoken_cancel_offer.rs
+++ b/src/models/transactions/nftoken_cancel_offer.rs
@@ -56,9 +56,17 @@ impl<'a: 'static> Model for NFTokenCancelOffer<'a> {
     }
 }
 
-impl<'a> Transaction<NoFlags> for NFTokenCancelOffer<'a> {
+impl<'a> Transaction<'a, NoFlags> for NFTokenCancelOffer<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -102,6 +110,9 @@ impl<'a> NFTokenCancelOffer<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             nftoken_offers,
         }

--- a/src/models/transactions/nftoken_mint.rs
+++ b/src/models/transactions/nftoken_mint.rs
@@ -105,13 +105,21 @@ impl<'a: 'static> Model for NFTokenMint<'a> {
     }
 }
 
-impl<'a> Transaction<NFTokenMintFlag> for NFTokenMint<'a> {
+impl<'a> Transaction<'a, NFTokenMintFlag> for NFTokenMint<'a> {
     fn has_flag(&self, flag: &NFTokenMintFlag) -> bool {
         self.common_fields.has_flag(flag)
     }
 
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NFTokenMintFlag> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NFTokenMintFlag> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -197,6 +205,9 @@ impl<'a> NFTokenMint<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             nftoken_taxon,
             issuer,

--- a/src/models/transactions/offer_cancel.rs
+++ b/src/models/transactions/offer_cancel.rs
@@ -43,9 +43,17 @@ pub struct OfferCancel<'a> {
 
 impl<'a> Model for OfferCancel<'a> {}
 
-impl<'a> Transaction<NoFlags> for OfferCancel<'a> {
+impl<'a> Transaction<'a, NoFlags> for OfferCancel<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -75,6 +83,9 @@ impl<'a> OfferCancel<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             offer_sequence,
         }

--- a/src/models/transactions/offer_create.rs
+++ b/src/models/transactions/offer_create.rs
@@ -81,13 +81,21 @@ pub struct OfferCreate<'a> {
 
 impl<'a> Model for OfferCreate<'a> {}
 
-impl<'a> Transaction<OfferCreateFlag> for OfferCreate<'a> {
+impl<'a> Transaction<'a, OfferCreateFlag> for OfferCreate<'a> {
     fn has_flag(&self, flag: &OfferCreateFlag) -> bool {
         self.common_fields.has_flag(flag)
     }
 
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, OfferCreateFlag> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, OfferCreateFlag> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -121,6 +129,9 @@ impl<'a> OfferCreate<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             taker_gets,
             taker_pays,

--- a/src/models/transactions/payment.rs
+++ b/src/models/transactions/payment.rs
@@ -105,13 +105,21 @@ impl<'a: 'static> Model for Payment<'a> {
     }
 }
 
-impl<'a> Transaction<PaymentFlag> for Payment<'a> {
+impl<'a> Transaction<'a, PaymentFlag> for Payment<'a> {
     fn has_flag(&self, flag: &PaymentFlag) -> bool {
         self.common_fields.has_flag(flag)
     }
 
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, PaymentFlag> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, PaymentFlag> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -220,6 +228,9 @@ impl<'a> Payment<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             amount,
             destination,

--- a/src/models/transactions/payment_channel_claim.rs
+++ b/src/models/transactions/payment_channel_claim.rs
@@ -90,13 +90,21 @@ pub struct PaymentChannelClaim<'a> {
 
 impl<'a> Model for PaymentChannelClaim<'a> {}
 
-impl<'a> Transaction<PaymentChannelClaimFlag> for PaymentChannelClaim<'a> {
+impl<'a> Transaction<'a, PaymentChannelClaimFlag> for PaymentChannelClaim<'a> {
     fn has_flag(&self, flag: &PaymentChannelClaimFlag) -> bool {
         self.common_fields.has_flag(flag)
     }
 
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, PaymentChannelClaimFlag> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, PaymentChannelClaimFlag> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -131,6 +139,9 @@ impl<'a> PaymentChannelClaim<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             channel,
             balance,

--- a/src/models/transactions/payment_channel_create.rs
+++ b/src/models/transactions/payment_channel_create.rs
@@ -60,9 +60,17 @@ pub struct PaymentChannelCreate<'a> {
 
 impl<'a> Model for PaymentChannelCreate<'a> {}
 
-impl<'a> Transaction<NoFlags> for PaymentChannelCreate<'a> {
+impl<'a> Transaction<'a, NoFlags> for PaymentChannelCreate<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -97,6 +105,9 @@ impl<'a> PaymentChannelCreate<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             amount,
             destination,

--- a/src/models/transactions/payment_channel_fund.rs
+++ b/src/models/transactions/payment_channel_fund.rs
@@ -52,9 +52,17 @@ pub struct PaymentChannelFund<'a> {
 
 impl<'a> Model for PaymentChannelFund<'a> {}
 
-impl<'a> Transaction<NoFlags> for PaymentChannelFund<'a> {
+impl<'a> Transaction<'a, NoFlags> for PaymentChannelFund<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -86,6 +94,9 @@ impl<'a> PaymentChannelFund<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             amount,
             channel,

--- a/src/models/transactions/pseudo_transactions/enable_amendment.rs
+++ b/src/models/transactions/pseudo_transactions/enable_amendment.rs
@@ -52,13 +52,21 @@ pub struct EnableAmendment<'a> {
 
 impl<'a> Model for EnableAmendment<'a> {}
 
-impl<'a> Transaction<EnableAmendmentFlag> for EnableAmendment<'a> {
+impl<'a> Transaction<'a, EnableAmendmentFlag> for EnableAmendment<'a> {
     fn has_flag(&self, flag: &EnableAmendmentFlag) -> bool {
         self.common_fields.has_flag(flag)
     }
 
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, EnableAmendmentFlag> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, EnableAmendmentFlag> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -90,6 +98,9 @@ impl<'a> EnableAmendment<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             amendment,
             ledger_sequence,

--- a/src/models/transactions/pseudo_transactions/set_fee.rs
+++ b/src/models/transactions/pseudo_transactions/set_fee.rs
@@ -41,9 +41,17 @@ pub struct SetFee<'a> {
 
 impl<'a> Model for SetFee<'a> {}
 
-impl<'a> Transaction<NoFlags> for SetFee<'a> {
+impl<'a> Transaction<'a, NoFlags> for SetFee<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -77,6 +85,9 @@ impl<'a> SetFee<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             base_fee,
             reference_fee_units,

--- a/src/models/transactions/pseudo_transactions/unl_modify.rs
+++ b/src/models/transactions/pseudo_transactions/unl_modify.rs
@@ -50,9 +50,17 @@ pub struct UNLModify<'a> {
 
 impl<'a> Model for UNLModify<'a> {}
 
-impl<'a> Transaction<NoFlags> for UNLModify<'a> {
+impl<'a> Transaction<'a, NoFlags> for UNLModify<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -84,6 +92,9 @@ impl<'a> UNLModify<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             ledger_sequence,
             unlmodify_disabling,

--- a/src/models/transactions/set_regular_key.rs
+++ b/src/models/transactions/set_regular_key.rs
@@ -47,9 +47,17 @@ pub struct SetRegularKey<'a> {
 
 impl<'a> Model for SetRegularKey<'a> {}
 
-impl<'a> Transaction<NoFlags> for SetRegularKey<'a> {
+impl<'a> Transaction<'a, NoFlags> for SetRegularKey<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -79,6 +87,9 @@ impl<'a> SetRegularKey<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             regular_key,
         }

--- a/src/models/transactions/signer_list_set.rs
+++ b/src/models/transactions/signer_list_set.rs
@@ -74,9 +74,17 @@ impl<'a> Model for SignerListSet<'a> {
     }
 }
 
-impl<'a> Transaction<NoFlags> for SignerListSet<'a> {
+impl<'a> Transaction<'a, NoFlags> for SignerListSet<'a> {
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -192,6 +200,9 @@ impl<'a> SignerListSet<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             signer_quorum,
             signer_entries,

--- a/src/models/transactions/ticket_create.rs
+++ b/src/models/transactions/ticket_create.rs
@@ -41,9 +41,17 @@ pub struct TicketCreate<'a> {
 
 impl<'a> Model for TicketCreate<'a> {}
 
-impl<'a> Transaction<NoFlags> for TicketCreate<'a> {
+impl<'a> Transaction<'a, NoFlags> for TicketCreate<'a> {
     fn get_transaction_type(&self) -> TransactionType {
         self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, NoFlags> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, NoFlags> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -73,6 +81,9 @@ impl<'a> TicketCreate<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             ticket_count,
         }

--- a/src/models/transactions/trust_set.rs
+++ b/src/models/transactions/trust_set.rs
@@ -72,13 +72,21 @@ pub struct TrustSet<'a> {
 
 impl<'a> Model for TrustSet<'a> {}
 
-impl<'a> Transaction<TrustSetFlag> for TrustSet<'a> {
+impl<'a> Transaction<'a, TrustSetFlag> for TrustSet<'a> {
     fn has_flag(&self, flag: &TrustSetFlag) -> bool {
         self.common_fields.has_flag(flag)
     }
 
     fn get_transaction_type(&self) -> TransactionType {
-        self.common_fields.transaction_type.clone()
+        self.common_fields.get_transaction_type()
+    }
+
+    fn get_common_fields(&self) -> &CommonFields<'_, TrustSetFlag> {
+        self.common_fields.get_common_fields()
+    }
+
+    fn get_mut_common_fields(&mut self) -> &mut CommonFields<'a, TrustSetFlag> {
+        self.common_fields.get_mut_common_fields()
     }
 }
 
@@ -111,6 +119,9 @@ impl<'a> TrustSet<'a> {
                 signers,
                 source_tag,
                 ticket_sequence,
+                network_id: None,
+                signing_pub_key: None,
+                txn_signature: None,
             },
             limit_amount,
             quality_in,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,19 +5,12 @@ mod integration;
 
 use anyhow::Result;
 
-#[cfg(any(
-    feature = "websocket-std",
-    all(feature = "websocket", feature = "std")
-))]
+#[cfg(any(feature = "websocket-std", all(feature = "websocket", feature = "std")))]
 #[tokio::test]
 async fn test_asynch_clients() -> Result<()> {
     #[cfg(all(feature = "websocket-std", not(feature = "websocket")))]
     return integration::clients::test_websocket_tungstenite_test_net().await;
-    #[cfg(all(
-        feature = "websocket",
-        feature = "std",
-        not(feature = "websocket-std")
-    ))]
+    #[cfg(all(feature = "websocket", feature = "std", not(feature = "websocket-std")))]
     return integration::clients::test_embedded_websocket_echo().await;
     #[allow(unreachable_code)]
     Ok(())
@@ -26,17 +19,9 @@ async fn test_asynch_clients() -> Result<()> {
 #[cfg(any(feature = "websocket-std", feature = "websocket", feature = "std"))]
 #[tokio::test]
 async fn test_asynch_clients_request() -> Result<()> {
-    #[cfg(all(
-        feature = "websocket-std",
-        feature = "std",
-        not(feature = "websocket")
-    ))]
+    #[cfg(all(feature = "websocket-std", feature = "std", not(feature = "websocket")))]
     return integration::clients::test_websocket_tungstenite_request().await;
-    #[cfg(all(
-        feature = "websocket",
-        feature = "std",
-        not(feature = "websocket-std")
-    ))]
+    #[cfg(all(feature = "websocket", feature = "std", not(feature = "websocket-std")))]
     return integration::clients::test_embedded_websocket_request().await;
     #[allow(unreachable_code)]
     Ok(())


### PR DESCRIPTION
## High Level Overview of Change

This is a updated version of #76 

Adds transaction auto filling feature. Transactions have [fields that can be filled automatically](https://xrpl.org/docs/references/protocol/transactions/common-fields/#auto-fillable-fields). This PR is required for #71 

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

## TODO
- [x] fix mutable borrow issues
- [x] add testing
- [x] handle unwraps
