### PR TITLE
fix: missing network_id member added to server info response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+- missing network_id member added to server info response
+
 ## [[v0.5.0]]
 
 - add missing NFT request models

--- a/src/models/results/server_info.rs
+++ b/src/models/results/server_info.rs
@@ -47,6 +47,8 @@ pub struct Info<'a> {
     pub load_factor_fee_queue: Option<u32>,
     /// Transaction cost multiplier excluding open ledger
     pub load_factor_server: Option<u32>,
+    /// Network id for ledger
+    pub network_id: Option<u32>,
     /// Number of connected peer servers
     pub peers: u32,
     /// List of ports listening for API commands
@@ -155,6 +157,7 @@ mod tests {
                     "proposers": 35
                 },
                 "load_factor": 1,
+                "network_id": 10,
                 "peers": 22,
                 "ports": [
                     {
@@ -202,6 +205,7 @@ mod tests {
         assert_eq!(result.info.last_close.converge_time_s, 3);
         assert_eq!(result.info.last_close.proposers, 35);
         assert_eq!(result.info.load_factor, 1);
+        assert_eq!(result.info.network_id, Some(10));
         assert_eq!(result.info.peers, 22);
         assert_eq!(
             result.info.pubkey_node,


### PR DESCRIPTION
## High Level Overview of Change
Added missing network_id field as an optional member in the server info response, as it is included in the [standard](https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/server-info-methods/server_info#server_info) response format.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)