### PR TITLE
Fix AsyncJsonRpcClient to reuse HttpClient

### DIFF
--- a/src/asynch/clients/json_rpc/mod.rs
+++ b/src/asynch/clients/json_rpc/mod.rs
@@ -45,11 +45,15 @@ mod _std {
 
     pub struct AsyncJsonRpcClient {
         url: Url,
+        client: HttpClient,
     }
 
     impl AsyncJsonRpcClient {
         pub fn connect(url: Url) -> Self {
-            Self { url }
+            Self {
+                url,
+                client: HttpClient::new(),
+            }
         }
     }
 
@@ -58,9 +62,9 @@ mod _std {
             &self,
             request: XRPLRequest<'a>,
         ) -> XRPLClientResult<XRPLResponse<'b>> {
-            let client = HttpClient::new();
             let request_json_rpc = request_to_json_rpc(&request)?;
-            let response = client
+            let response = self
+                .client
                 .post(self.url.as_ref())
                 .json(&request_json_rpc)
                 .send()


### PR DESCRIPTION
## High Level Overview of Change

* Simple fix for AsyncJsonRpcClient to reuse the HttpClient connection

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

`AsyncJsonRpcClient` is creating a new `HttpClient` for each request. The fix makes `AsyncJsonRpcClient` reuse the client connection.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

```
2025-06-19T15:08:48.013111Z  INFO xrp_app: Call 0: Account balance: 1.99975 XRP
2025-06-19T15:08:48.027369Z DEBUG get_account_balance: reqwest::connect: starting new connection: https://s.altnet.rippletest.net:51234/ 
2025-06-19T15:08:48.028163Z DEBUG get_account_balance: hyper_util::client::legacy::connect::http: connecting to 35.171.235.228:51234
2025-06-19T15:08:48.144391Z DEBUG get_account_balance: hyper_util::client::legacy::connect::http: connected to 35.171.235.228:51234
2025-06-19T15:08:48.538461Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:08:48.538618Z  INFO xrp_app: Call 1: Account balance: 1.99975 XRP
2025-06-19T15:08:48.551663Z DEBUG get_account_balance: reqwest::connect: starting new connection: https://s.altnet.rippletest.net:51234/ 
2025-06-19T15:08:48.552626Z DEBUG get_account_balance: hyper_util::client::legacy::connect::http: connecting to 35.171.235.228:51234
2025-06-19T15:08:48.668859Z DEBUG get_account_balance: hyper_util::client::legacy::connect::http: connected to 35.171.235.228:51234
2025-06-19T15:08:49.061919Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:08:49.062203Z  INFO xrp_app: Call 2: Account balance: 1.99975 XRP
2025-06-19T15:08:49.076024Z DEBUG get_account_balance: reqwest::connect: starting new connection: https://s.altnet.rippletest.net:51234/ 
2025-06-19T15:08:49.076678Z DEBUG get_account_balance: hyper_util::client::legacy::connect::http: connecting to 35.171.235.228:51234
2025-06-19T15:08:49.192298Z DEBUG get_account_balance: hyper_util::client::legacy::connect::http: connected to 35.171.235.228:51234
2025-06-19T15:08:49.585268Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:08:49.585566Z  INFO xrp_app: Call 3: Account balance: 1.99975 XRP
2025-06-19T15:08:49.598022Z DEBUG get_account_balance: reqwest::connect: starting new connection: https://s.altnet.rippletest.net:51234/ 
2025-06-19T15:08:49.599128Z DEBUG get_account_balance: hyper_util::client::legacy::connect::http: connecting to 35.171.235.228:51234
2025-06-19T15:08:49.714901Z DEBUG get_account_balance: hyper_util::client::legacy::connect::http: connected to 35.171.235.228:51234
2025-06-19T15:08:50.106887Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:08:50.107174Z  INFO xrp_app: Call 4: Account balance: 1.99975 XRP
2025-06-19T15:08:50.119358Z DEBUG get_account_next_valid_sequence: reqwest::connect: starting new connection: https://s.altnet.rippletest.net:51234/
2025-06-19T15:08:50.120389Z DEBUG get_account_next_valid_sequence: hyper_util::client::legacy::connect::http: connecting to 35.171.235.228:51234
2025-06-19T15:08:50.239872Z DEBUG get_account_next_valid_sequence: hyper_util::client::legacy::connect::http: connected to 35.171.235.228:51234
2025-06-19T15:08:50.634226Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)
```

After patch applied:

```
2025-06-19T15:11:35.204603Z  INFO xrp_app: Call 0: Account balance: 1.99975 XRP       
2025-06-19T15:11:35.204858Z DEBUG get_account_balance: hyper_util::client::legacy::pool: reuse idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:11:35.480795Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)2025-06-19T15:11:35.481047Z  INFO xrp_app: Call 1: Account balance: 1.99975 XRP   
2025-06-19T15:11:35.481201Z DEBUG get_account_balance: hyper_util::client::legacy::pool: reuse idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:11:35.604840Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:11:35.605091Z  INFO xrp_app: Call 2: Account balance: 1.99975 XRP   
2025-06-19T15:11:35.605243Z DEBUG get_account_balance: hyper_util::client::legacy::pool: reuse idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:11:35.878113Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)2025-06-19T15:11:35.878331Z  INFO xrp_app: Call 3: Account balance: 1.99975 XRP   
2025-06-19T15:11:35.878548Z DEBUG get_account_balance: hyper_util::client::legacy::pool: reuse idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:11:36.152513Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:11:36.152762Z  INFO xrp_app: Call 4: Account balance: 1.99975 XRP   
2025-06-19T15:11:36.152910Z DEBUG get_account_next_valid_sequence: hyper_util::client::legacy::pool: reuse idle connection for ("https", s.altnet.rippletest.net:51234)
2025-06-19T15:11:36.424893Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", s.altnet.rippletest.net:51234)
```


## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
