### PR TITLE
ci: measure integration-test coverage (#297, infra half)

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -48,10 +48,34 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-integration-
 
-      - name: Run integration tests
-        run: cargo test --release --features std,json-rpc,helpers,integration --test integration_test -- --test-threads=1
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run integration tests with coverage
+        run: |
+          cargo llvm-cov \
+            --release \
+            --features std,json-rpc,helpers,integration \
+            --test integration_test \
+            --lcov \
+            --output-path integration-lcov.info \
+            -- --test-threads=1
         env:
           RUST_BACKTRACE: 1
+
+      - name: Integration coverage summary
+        # Prints the line / region / function percentages so they land in the run log
+        # and become trivially observable in PR runs. The `--fail-under-*` gates are
+        # intentionally not enabled yet (#297): pick realistic thresholds after a few
+        # baseline runs land, matching how `unit_test.yml`'s thresholds were tuned.
+        run: cargo llvm-cov report --summary-only
+
+      - name: Upload integration coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-lcov-report
+          path: integration-lcov.info
 
       - name: Dump xrpld logs and stop container
         if: always()


### PR DESCRIPTION
Partial fix for #297.

## What this PR does

Wraps the existing integration test step in `cargo llvm-cov` so each CI run produces an lcov.info for the `--features std,json-rpc,helpers,integration --test integration_test` set, prints the summary to the run log, and uploads the report as an artifact.

```yaml
- name: Run integration tests with coverage
  run: |
    cargo llvm-cov \
      --release \
      --features std,json-rpc,helpers,integration \
      --test integration_test \
      --lcov \
      --output-path integration-lcov.info \
      -- --test-threads=1

- name: Integration coverage summary
  run: cargo llvm-cov report --summary-only
```

## What this PR doesn't do

- **Does not set a `--fail-under-*` threshold yet.** The right line / region / function thresholds depend on what the integration suite actually covers today. Same approach `unit_test.yml` took: thresholds were tuned to current reality (73 / 75 / 67). After a few baseline runs from this PR land, set thresholds slightly below the observed numbers — happy to send a follow-up.
- **Does not add new integration tests.** The other half of #297 calls for new tests around `asynch::clients::**`, `account/`, `ledger/`, `transaction/mod.rs`, and the faucet client. That work needs to see the measured baseline first, so it's natural to split.

## Smoke gate

YAML-only change; the workflow will itself prove the SHAs and the command shape work when CI runs on this PR.