### PR TITLE
fix(#166): preserve Utf8Error detail in hex_to_str

### DIFF
--- a/src/utils/exceptions.rs
+++ b/src/utils/exceptions.rs
@@ -39,8 +39,8 @@ pub enum XRPLUtilsException {
     FromHexError(#[from] hex::FromHexError),
     #[error("ParseInt error: {0}")]
     ParseIntError(#[from] core::num::ParseIntError),
-    #[error("Invalid UTF-8")]
-    Utf8Error,
+    #[error("Invalid UTF-8: {0}")]
+    Utf8Error(#[from] core::str::Utf8Error),
 }
 
 #[derive(Debug, Clone, PartialEq, Error)]
@@ -117,12 +117,6 @@ pub enum ISOCodeException {
     InvalidXRPBytes,
     #[error("Invalid Currency representation")]
     UnsupportedCurrencyRepresentation,
-}
-
-impl From<core::str::Utf8Error> for XRPLUtilsException {
-    fn from(_: core::str::Utf8Error) -> Self {
-        XRPLUtilsException::Utf8Error
-    }
 }
 
 impl From<serde_json::Error> for XRPLUtilsException {

--- a/src/utils/str_conversion.rs
+++ b/src/utils/str_conversion.rs
@@ -63,4 +63,16 @@ mod tests {
         let result = hex_to_str(Cow::Borrowed("ff"));
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_hex_to_str_invalid_utf8_preserves_detail() {
+        use crate::utils::exceptions::XRPLUtilsException;
+
+        // "41ff" decodes to [0x41, 0xff]: 'A' is valid, 0xff is not, so the
+        // Utf8Error should report `valid_up_to() == 1`.
+        match hex_to_str(Cow::Borrowed("41ff")).unwrap_err() {
+            XRPLUtilsException::Utf8Error(error) => assert_eq!(error.valid_up_to(), 1),
+            other => panic!("expected Utf8Error, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
Closes #166.

`XRPLUtilsException::Utf8Error` was a unit variant, and its `From<core::str::Utf8Error>` impl ignored its argument (`fn from(_) -> Self`). Every UTF-8 failure in `hex_to_str` therefore collapsed to a detail-free "Invalid UTF-8", discarding the `Utf8Error` position (`valid_up_to()` / `error_len()`).

The variant now carries the underlying `core::str::Utf8Error` (via `#[from]`), so callers can diagnose exactly which byte was invalid.

### Testing
- `cargo test --lib` — added `test_hex_to_str_invalid_utf8_preserves_detail`
- `cargo fmt --check`, `cargo test --doc`
- no_std feature set (`--no-default-features --features embassy-rt,core,utils,wallet,models,helpers,websocket,json-rpc`) builds and tests green
