### PR TITLE
fix(#167): locate XChainOwnedClaimID by type, not by index

### DIFF
--- a/src/utils/get_xchain_claim_id.rs
+++ b/src/utils/get_xchain_claim_id.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::Cow, vec::Vec};
+use alloc::borrow::Cow;
 
 use crate::models::{
     ledger::objects::LedgerEntryType, transactions::metadata::TransactionMetadata,
@@ -10,38 +10,24 @@ use crate::models::transactions::metadata::AffectedNode;
 pub fn get_xchain_claim_id<'a: 'b, 'b>(
     meta: &TransactionMetadata<'a>,
 ) -> XRPLUtilsResult<Cow<'b, str>> {
-    let affected_nodes: Vec<&AffectedNode> = meta
-        .affected_nodes
+    // `AffectedNodes` ordering is not guaranteed by the server, so search for
+    // the created `XChainOwnedClaimID` entry by type and field rather than
+    // trusting a positional index.
+    meta.affected_nodes
         .iter()
-        .filter(|node| {
-            // node.is_created_node() && node.created_node().ledger_entry_type == "XChainOwnedClaimID"
-            match node {
-                AffectedNode::CreatedNode {
-                    ledger_entry_type, ..
-                } => ledger_entry_type == &LedgerEntryType::XChainOwnedClaimID,
-                _ => false,
+        .find_map(|node| match node {
+            AffectedNode::CreatedNode {
+                ledger_entry_type,
+                new_fields,
+                ..
+            } if ledger_entry_type == &LedgerEntryType::XChainOwnedClaimID => {
+                new_fields.xchain_claim_id.clone()
             }
+            _ => None,
         })
-        .collect();
-
-    if affected_nodes.is_empty() {
-        Err(XRPLXChainClaimIdException::NoXChainOwnedClaimID.into())
-    } else {
-        match affected_nodes[0] {
-            AffectedNode::CreatedNode { new_fields, .. } => {
-                if let Some(xchain_claim_id) = new_fields.xchain_claim_id.as_ref() {
-                    Ok(xchain_claim_id.clone())
-                } else {
-                    Err(XRPLUtilsException::XRPLXChainClaimIdError(
-                        XRPLXChainClaimIdException::NoXChainOwnedClaimID,
-                    ))
-                }
-            }
-            _ => Err(XRPLUtilsException::XRPLXChainClaimIdError(
-                XRPLXChainClaimIdException::NoXChainOwnedClaimID,
-            )),
-        }
-    }
+        .ok_or(XRPLUtilsException::XRPLXChainClaimIdError(
+            XRPLXChainClaimIdException::NoXChainOwnedClaimID,
+        ))
 }
 
 #[cfg(test)]
@@ -112,6 +98,41 @@ mod tests {
         let meta: TransactionMetadata = serde_json::from_str(json).unwrap();
         let result = get_xchain_claim_id(&meta);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_xchain_claim_id_not_first_node() {
+        // The XChainOwnedClaimID created node is not at index 0; the lookup
+        // must still find it by type rather than trusting the ordering.
+        let json = r#"{
+            "AffectedNodes": [
+                {
+                    "CreatedNode": {
+                        "LedgerEntryType": "AccountRoot",
+                        "LedgerIndex": "991ED60C316200D33B2EA3E56E505433394DBA7FF5E7ADE8C8850D02BEF1F53A",
+                        "NewFields": {
+                            "Account": "rHzKtpcB1KC1YuU4PBhk9m2abqrf2kZsfV",
+                            "Flags": 0
+                        }
+                    }
+                },
+                {
+                    "CreatedNode": {
+                        "LedgerEntryType": "XChainOwnedClaimID",
+                        "LedgerIndex": "AA1ED60C316200D33B2EA3E56E505433394DBA7FF5E7ADE8C8850D02BEF1F53A",
+                        "NewFields": {
+                            "Account": "rPV4mZjsXfH2HvUSPLNmqz1J8d3Lpv7tpe",
+                            "Flags": 0,
+                            "XchainClaimId": "abc"
+                        }
+                    }
+                }
+            ],
+            "TransactionIndex": 0,
+            "TransactionResult": "tesSUCCESS"
+        }"#;
+        let meta: TransactionMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(get_xchain_claim_id(&meta).unwrap(), "abc");
     }
 
     #[test]


### PR DESCRIPTION
Closes #167.

`get_xchain_claim_id` returned the claim id from `affected_nodes[0]` after filtering by type. `AffectedNodes` ordering is not guaranteed by the server, and the first matching created node is not guaranteed to be the one carrying the field.

Replaces the positional lookup with a `find_map` that returns the first created `XChainOwnedClaimID` entry actually carrying an `xchain_claim_id`, regardless of position.

### Testing
- `cargo test --lib` — added `test_get_xchain_claim_id_not_first_node`; existing tests still pass
- `cargo fmt --check`; no_std feature set green
