### PR TITLE
fix(#168): don't surface raw WS response body in send error

### DIFF
--- a/src/asynch/clients/websocket/exceptions.rs
+++ b/src/asynch/clients/websocket/exceptions.rs
@@ -38,8 +38,8 @@ pub enum XRPLWebSocketException {
     MissingRequestReceiver,
     #[error("Invalid message.")]
     InvalidMessage,
-    #[error("Failed to send message through channel: {0:?}")]
-    MessageChannelError(String),
+    #[error("Failed to send message through channel: the receiver was dropped")]
+    MessageChannelError,
     #[error("Failed to receive message through channel: {0:?}")]
     Canceled(#[from] Canceled),
     #[cfg(feature = "std")]

--- a/src/asynch/clients/websocket/websocket_base.rs
+++ b/src/asynch/clients/websocket/websocket_base.rs
@@ -77,9 +77,12 @@ where
                 Some(sender) => sender,
                 None => return Err(XRPLWebSocketException::MissingRequestSender.into()),
             };
+            // On failure `send` hands back the message that could not be
+            // delivered; discard it so the raw response body is not surfaced
+            // into error-reporting channels.
             sender
                 .send(message)
-                .map_err(XRPLWebSocketException::MessageChannelError)?;
+                .map_err(|_| XRPLWebSocketException::MessageChannelError)?;
         } else {
             self.messages.send(message).await;
         }
@@ -104,5 +107,38 @@ where
             Ok(None) => Ok(None),
             Err(error) => Err(XRPLWebSocketException::Canceled(error).into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asynch::clients::SingleExecutorMutex;
+    use embassy_futures::block_on;
+
+    #[test]
+    fn handle_message_routes_response_to_waiting_request() {
+        let mut base = WebsocketBase::<SingleExecutorMutex>::new();
+        block_on(async {
+            base.setup_request_future("1".to_string()).await;
+            base.handle_message(r#"{"id":"1","result":{}}"#.to_string())
+                .await
+                .unwrap();
+            let received = base.try_recv_request("1".to_string()).await.unwrap();
+            assert_eq!(received, Some(r#"{"id":"1","result":{}}"#.to_string()));
+        });
+    }
+
+    #[test]
+    fn unmatched_message_is_buffered_for_pop() {
+        let mut base = WebsocketBase::<SingleExecutorMutex>::new();
+        block_on(async {
+            // No request is registered, so the message falls through to the
+            // general message channel rather than a request receiver.
+            base.handle_message(r#"{"result":{}}"#.to_string())
+                .await
+                .unwrap();
+            assert_eq!(base.pop_message().await, r#"{"result":{}}"#.to_string());
+        });
     }
 }


### PR DESCRIPTION
Closes #168.

When the oneshot request receiver had been dropped, `Sender::send` handed back the undeliverable message and it was embedded verbatim into `MessageChannelError(String)`, surfacing the raw response body into error-reporting channels.

The undeliverable message is now discarded and `MessageChannelError` is a data-free variant.

### Testing
- `cargo test --lib` — added `handle_message_routes_response_to_waiting_request` and `unmatched_message_is_buffered_for_pop`
- `cargo fmt --check`; no_std feature set green
