### PR TITLE
fix(#173): reject non-ASCII NFT IDs before byte slicing

### DIFF
--- a/src/utils/exceptions.rs
+++ b/src/utils/exceptions.rs
@@ -84,6 +84,8 @@ pub enum XRPRangeException {
 pub enum XRPLNFTIdException {
     #[error("Invalid NFT ID length (expected: {expected} found: {found})")]
     InvalidNFTIdLength { expected: usize, found: usize },
+    #[error("Invalid NFT ID encoding (expected ASCII hex)")]
+    InvalidNFTIdEncoding,
 }
 
 #[derive(Debug, Clone, PartialEq, Error)]

--- a/src/utils/parse_nftoken_id.rs
+++ b/src/utils/parse_nftoken_id.rs
@@ -62,6 +62,12 @@ pub fn parse_nftoken_id(nft_id: Cow<'_, str>) -> XRPLUtilsResult<NFTokenId<'_>> 
         }
         .into());
     }
+    // A valid NFT ID is 64 ASCII hex characters. Guard against non-ASCII input
+    // so the byte-index slicing below cannot land on a UTF-8 char boundary and
+    // panic on an otherwise 64-byte string.
+    if !nft_id.is_ascii() {
+        return Err(XRPLNFTIdException::InvalidNFTIdEncoding.into());
+    }
     let scrambled_taxon = u64::from_str_radix(&nft_id[48..56], 16)?;
     let sequence = u32::from_str_radix(&nft_id[56..64], 16)?;
     let flags = u32::from_str_radix(&nft_id[0..4], 16)?;
@@ -92,5 +98,20 @@ mod tests {
         assert_eq!(nftoken_id.issuer, "rJoxBSzpXhPtAuqFmqxQtGKjA13jUJWthE");
         assert_eq!(nftoken_id.taxon, 1337);
         assert_eq!(nftoken_id.sequence, 12);
+    }
+
+    #[test]
+    fn test_parse_nftoken_id_non_ascii_returns_err_without_panic() {
+        use alloc::string::String;
+
+        // 47 ASCII chars followed by the 3-byte '€' makes byte index 48 fall in
+        // the middle of a UTF-8 character. The total length is 64 bytes, so the
+        // old byte-index slicing would panic; it must now return an error.
+        let mut nft_id = String::from("a".repeat(47));
+        nft_id.push('€');
+        nft_id.push_str(&"a".repeat(14));
+        assert_eq!(nft_id.len(), 64);
+
+        assert!(parse_nftoken_id(Cow::Owned(nft_id)).is_err());
     }
 }


### PR DESCRIPTION
Closes #173.

`parse_nftoken_id` length-checks by byte count and then slices `nft_id` at fixed byte offsets (`[0..4]`, `[48..56]`, ...). A 64-byte string containing multibyte UTF-8 could land a slice boundary mid-character and panic.

Adds an `is_ascii()` guard before slicing, returning the new `XRPLNFTIdException::InvalidNFTIdEncoding` for non-ASCII input.

### Testing
- `cargo test --lib` — added `test_parse_nftoken_id_non_ascii_returns_err_without_panic` (a 64-byte input that previously panicked)
- `cargo fmt --check`; no_std feature set green
