### PR TITLE
fix(#174): compile currency/precision regexes once via lazy_static

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -22,7 +22,15 @@ pub use self::xrpl_conversion::*;
 
 use crate::constants::*;
 use alloc::vec::Vec;
+use lazy_static::lazy_static;
 use regex::Regex;
+
+lazy_static! {
+    /// Matches a 40-character uppercase-hex currency code.
+    static ref HEX_CURRENCY_RE: Regex = Regex::new(HEX_CURRENCY_REGEX).expect("valid HEX_CURRENCY_REGEX");
+    /// Matches a 3-character ISO currency code.
+    static ref ISO_CURRENCY_RE: Regex = Regex::new(ISO_CURRENCY_REGEX).expect("valid ISO_CURRENCY_REGEX");
+}
 
 /// Determine if the address string is a hex address.
 ///
@@ -38,8 +46,7 @@ use regex::Regex;
 /// assert!(is_hex_address(value));
 /// ```
 pub fn is_hex_address(value: &str) -> bool {
-    let regex = Regex::new(HEX_CURRENCY_REGEX).expect("is_hex_address");
-    regex.is_match(value)
+    HEX_CURRENCY_RE.is_match(value)
 }
 
 /// Tests if value is a valid 3-char iso code.
@@ -56,8 +63,7 @@ pub fn is_hex_address(value: &str) -> bool {
 /// assert!(is_iso_code(value));
 /// ```
 pub fn is_iso_code(value: &str) -> bool {
-    let regex = Regex::new(ISO_CURRENCY_REGEX).expect("is_iso_code");
-    regex.is_match(value)
+    ISO_CURRENCY_RE.is_match(value)
 }
 
 /// Tests if value is a valid 40-char hex currency string.
@@ -74,8 +80,7 @@ pub fn is_iso_code(value: &str) -> bool {
 /// assert!(is_iso_hex(value));
 /// ```
 pub fn is_iso_hex(value: &str) -> bool {
-    let regex = Regex::new(HEX_CURRENCY_REGEX).expect("_is_hex");
-    regex.is_match(value)
+    HEX_CURRENCY_RE.is_match(value)
 }
 
 /// Converter to byte array with endianness.

--- a/src/utils/xrpl_conversion.rs
+++ b/src/utils/xrpl_conversion.rs
@@ -5,11 +5,17 @@ use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
 use bigdecimal::BigDecimal;
+use lazy_static::lazy_static;
 use regex::Regex;
 use rust_decimal::prelude::*;
 use rust_decimal::Decimal;
 
 use super::exceptions::XRPLUtilsResult;
+
+lazy_static! {
+    /// Matches every character that is not a significant digit (`1`-`9`).
+    static ref PRECISION_RE: Regex = Regex::new("[^1-9]").expect("valid precision regex");
+}
 
 /// Indivisible unit of XRP
 pub(crate) const _ONE_DROP: Decimal = Decimal::from_parts(1, 0, 0, false, 6);
@@ -76,16 +82,15 @@ fn checked_mul(first: &BigDecimal, second: &BigDecimal) -> Option<BigDecimal> {
 /// Get the precision of a number.
 fn _calculate_precision(value: &str) -> XRPLUtilsResult<usize> {
     let decimal = BigDecimal::from_str(value)?.normalized();
-    let regex = Regex::new("[^1-9]").expect("_calculate_precision");
 
     if checked_rem(&decimal, &BigDecimal::one()).is_some() {
-        let stripped = regex
+        let stripped = PRECISION_RE
             .replace(&decimal.to_string(), "")
             .replace(['.', '0'], "");
         Ok(stripped.len())
     } else {
         let quantized = decimal.with_scale(2);
-        let stripped = regex
+        let stripped = PRECISION_RE
             .replace(&quantized.to_string(), "")
             .replace(['.', '0'], "");
         Ok(stripped.len())


### PR DESCRIPTION
Closes #174.

`is_hex_address`, `is_iso_code`, `is_iso_hex` and `_calculate_precision` called `Regex::new(..)` on every invocation, recompiling the pattern on the hot path.

Caches the compiled regexes in `lazy_static` statics, matching the existing pattern used in `core/binarycodec/definitions`.

### Testing
- `cargo test --lib` and `cargo test --doc` (existing `is_hex_address` / `is_iso_code` / `is_iso_hex` coverage)
- `cargo fmt --check`; no_std feature set green
