### PR TITLE
Stabilize client network error coverage

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -76,7 +76,7 @@ jobs:
             --ignore-filename-regex '${{ env.COVERAGE_IGNORE_REGEX }}'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/src/asynch/clients/exceptions.rs
+++ b/src/asynch/clients/exceptions.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), feature = "websocket"))]
 use alloc::boxed::Box;
 use thiserror_no_std::Error;
 
@@ -12,6 +12,23 @@ use super::XRPLJsonRpcException;
 use super::XRPLWebSocketException;
 
 pub type XRPLClientResult<T, E = XRPLClientException> = core::result::Result<T, E>;
+
+/// Granular network/transport error categories for client failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum XRPLNetworkErrorKind {
+    ConnectionClosed,
+    AlreadyClosed,
+    ConnectionRefused,
+    ConnectionReset,
+    TimedOut,
+    Dns,
+    Tls,
+    Protocol,
+    InvalidResponse,
+    OtherIo,
+    Other,
+}
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -70,5 +87,77 @@ impl From<reqwest::Error> for XRPLClientException {
     }
 }
 
+impl XRPLClientException {
+    /// Return a typed network error category, if this is a transport failure.
+    pub fn network_error_kind(&self) -> Option<XRPLNetworkErrorKind> {
+        match self {
+            #[cfg(feature = "websocket")]
+            XRPLClientException::XRPLWebSocketError(error) => error.network_error_kind(),
+            #[cfg(feature = "json-rpc")]
+            XRPLClientException::XRPLJsonRpcError(error) => error.network_error_kind(),
+            #[cfg(feature = "std")]
+            XRPLClientException::IoError(error) => Some(match error.kind() {
+                alloc::io::ErrorKind::ConnectionRefused => XRPLNetworkErrorKind::ConnectionRefused,
+                alloc::io::ErrorKind::ConnectionReset => XRPLNetworkErrorKind::ConnectionReset,
+                alloc::io::ErrorKind::TimedOut => XRPLNetworkErrorKind::TimedOut,
+                _ => XRPLNetworkErrorKind::OtherIo,
+            }),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(feature = "std")]
 impl alloc::error::Error for XRPLClientException {}
+
+#[cfg(all(test, feature = "std", feature = "websocket", feature = "json-rpc"))]
+mod tests {
+    use alloc::boxed::Box;
+
+    use super::*;
+    use crate::asynch::clients::{XRPLJsonRpcException, XRPLWebSocketException};
+
+    #[test]
+    fn maps_client_network_error_kinds() {
+        let cases = [
+            (
+                XRPLClientException::XRPLWebSocketError(Box::new(
+                    XRPLWebSocketException::ConnectionClosed,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionClosed),
+            ),
+            (
+                XRPLClientException::XRPLJsonRpcError(XRPLJsonRpcException::RequestError(
+                    "not transport".into(),
+                )),
+                None,
+            ),
+            (
+                XRPLClientException::IoError(alloc::io::Error::from(
+                    alloc::io::ErrorKind::ConnectionRefused,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionRefused),
+            ),
+            (
+                XRPLClientException::IoError(alloc::io::Error::from(
+                    alloc::io::ErrorKind::ConnectionReset,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionReset),
+            ),
+            (
+                XRPLClientException::IoError(alloc::io::Error::from(
+                    alloc::io::ErrorKind::TimedOut,
+                )),
+                Some(XRPLNetworkErrorKind::TimedOut),
+            ),
+            (
+                XRPLClientException::IoError(alloc::io::Error::from(alloc::io::ErrorKind::Other)),
+                Some(XRPLNetworkErrorKind::OtherIo),
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.network_error_kind(), expected);
+        }
+    }
+}

--- a/src/asynch/clients/json_rpc/exceptions.rs
+++ b/src/asynch/clients/json_rpc/exceptions.rs
@@ -2,6 +2,8 @@ use alloc::string::String;
 
 use thiserror_no_std::Error;
 
+use crate::asynch::clients::exceptions::XRPLNetworkErrorKind;
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum XRPLJsonRpcException {
@@ -12,4 +14,35 @@ pub enum XRPLJsonRpcException {
     ReqwestError(#[from] reqwest::Error),
     #[error("Request error: {0}")]
     RequestError(String),
+}
+
+impl XRPLJsonRpcException {
+    /// Return a typed network error category, if this JSON-RPC failure is transport-related.
+    pub fn network_error_kind(&self) -> Option<XRPLNetworkErrorKind> {
+        match self {
+            #[cfg(feature = "std")]
+            XRPLJsonRpcException::ReqwestError(error) => {
+                if error.is_timeout() {
+                    Some(XRPLNetworkErrorKind::TimedOut)
+                } else if error.is_connect() {
+                    Some(XRPLNetworkErrorKind::OtherIo)
+                } else {
+                    None
+                }
+            }
+            XRPLJsonRpcException::ReqwlessError(_) => Some(XRPLNetworkErrorKind::OtherIo),
+            XRPLJsonRpcException::RequestError(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_errors_are_not_network_errors() {
+        let error = XRPLJsonRpcException::RequestError("bad request".into());
+        assert_eq!(error.network_error_kind(), None);
+    }
 }

--- a/src/asynch/clients/websocket/exceptions.rs
+++ b/src/asynch/clients/websocket/exceptions.rs
@@ -1,4 +1,6 @@
 use alloc::string::String;
+#[cfg(feature = "std")]
+use alloc::string::ToString;
 use core::fmt::Debug;
 use core::str::Utf8Error;
 #[cfg(all(feature = "websocket", not(feature = "std")))]
@@ -7,6 +9,8 @@ use embedded_io_async::{Error as EmbeddedIoError, ErrorKind};
 use embedded_websocket_embedded_io::framer_async::FramerError;
 use futures::channel::oneshot::Canceled;
 use thiserror_no_std::Error;
+
+use crate::asynch::clients::exceptions::XRPLNetworkErrorKind;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -43,8 +47,26 @@ pub enum XRPLWebSocketException {
     #[error("Failed to receive message through channel: {0:?}")]
     Canceled(#[from] Canceled),
     #[cfg(feature = "std")]
-    #[error("Tungstenite error: {0:?}")]
-    TungsteniteError(#[from] tokio_tungstenite::tungstenite::Error),
+    #[error("WebSocket I/O error: {0:?}")]
+    TungsteniteIo(alloc::io::Error),
+    #[cfg(feature = "std")]
+    #[error("WebSocket connection closed")]
+    ConnectionClosed,
+    #[cfg(feature = "std")]
+    #[error("WebSocket connection already closed")]
+    AlreadyClosed,
+    #[cfg(feature = "std")]
+    #[error("WebSocket protocol error: {0}")]
+    Protocol(String),
+    #[cfg(feature = "std")]
+    #[error("WebSocket capacity error: {0}")]
+    Capacity(String),
+    #[cfg(feature = "std")]
+    #[error("WebSocket TLS error: {0}")]
+    Tls(String),
+    #[cfg(feature = "std")]
+    #[error("Tungstenite error: {0}")]
+    Tungstenite(String),
 }
 
 #[cfg(all(feature = "websocket", not(feature = "std")))]
@@ -75,4 +97,126 @@ impl EmbeddedIoError for XRPLWebSocketException {
 }
 
 #[cfg(feature = "std")]
+impl From<tokio_tungstenite::tungstenite::Error> for XRPLWebSocketException {
+    fn from(error: tokio_tungstenite::tungstenite::Error) -> Self {
+        use tokio_tungstenite::tungstenite::Error;
+
+        match error {
+            Error::ConnectionClosed => XRPLWebSocketException::ConnectionClosed,
+            Error::AlreadyClosed => XRPLWebSocketException::AlreadyClosed,
+            Error::Io(error) => XRPLWebSocketException::TungsteniteIo(error),
+            Error::Tls(error) => XRPLWebSocketException::Tls(error.to_string()),
+            Error::Capacity(error) => XRPLWebSocketException::Capacity(error.to_string()),
+            Error::Protocol(error) => XRPLWebSocketException::Protocol(error.to_string()),
+            error => XRPLWebSocketException::Tungstenite(error.to_string()),
+        }
+    }
+}
+
+impl XRPLWebSocketException {
+    /// Return a typed network error category, if this websocket failure is transport-related.
+    pub fn network_error_kind(&self) -> Option<XRPLNetworkErrorKind> {
+        match self {
+            XRPLWebSocketException::Disconnected => Some(XRPLNetworkErrorKind::ConnectionClosed),
+            #[cfg(feature = "std")]
+            XRPLWebSocketException::ConnectionClosed => {
+                Some(XRPLNetworkErrorKind::ConnectionClosed)
+            }
+            #[cfg(feature = "std")]
+            XRPLWebSocketException::AlreadyClosed => Some(XRPLNetworkErrorKind::AlreadyClosed),
+            #[cfg(feature = "std")]
+            XRPLWebSocketException::TungsteniteIo(error) => Some(match error.kind() {
+                alloc::io::ErrorKind::ConnectionRefused => XRPLNetworkErrorKind::ConnectionRefused,
+                alloc::io::ErrorKind::ConnectionReset => XRPLNetworkErrorKind::ConnectionReset,
+                alloc::io::ErrorKind::TimedOut => XRPLNetworkErrorKind::TimedOut,
+                _ => XRPLNetworkErrorKind::OtherIo,
+            }),
+            #[cfg(feature = "std")]
+            XRPLWebSocketException::Tls(_) => Some(XRPLNetworkErrorKind::Tls),
+            #[cfg(feature = "std")]
+            XRPLWebSocketException::Protocol(_) => Some(XRPLNetworkErrorKind::Protocol),
+            XRPLWebSocketException::InvalidMessage
+            | XRPLWebSocketException::UnexpectedMessageType => {
+                Some(XRPLNetworkErrorKind::InvalidResponse)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
 impl alloc::error::Error for XRPLWebSocketException {}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_tungstenite_io_error_kind() {
+        let error = tokio_tungstenite::tungstenite::Error::Io(alloc::io::Error::from(
+            alloc::io::ErrorKind::ConnectionRefused,
+        ));
+        let error = XRPLWebSocketException::from(error);
+        assert_eq!(
+            error.network_error_kind(),
+            Some(XRPLNetworkErrorKind::ConnectionRefused)
+        );
+    }
+
+    #[test]
+    fn maps_std_websocket_network_error_kinds() {
+        let cases = [
+            (
+                XRPLWebSocketException::Disconnected,
+                Some(XRPLNetworkErrorKind::ConnectionClosed),
+            ),
+            (
+                XRPLWebSocketException::ConnectionClosed,
+                Some(XRPLNetworkErrorKind::ConnectionClosed),
+            ),
+            (
+                XRPLWebSocketException::AlreadyClosed,
+                Some(XRPLNetworkErrorKind::AlreadyClosed),
+            ),
+            (
+                XRPLWebSocketException::TungsteniteIo(alloc::io::Error::from(
+                    alloc::io::ErrorKind::ConnectionReset,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionReset),
+            ),
+            (
+                XRPLWebSocketException::TungsteniteIo(alloc::io::Error::from(
+                    alloc::io::ErrorKind::TimedOut,
+                )),
+                Some(XRPLNetworkErrorKind::TimedOut),
+            ),
+            (
+                XRPLWebSocketException::TungsteniteIo(alloc::io::Error::from(
+                    alloc::io::ErrorKind::Other,
+                )),
+                Some(XRPLNetworkErrorKind::OtherIo),
+            ),
+            (
+                XRPLWebSocketException::Tls("tls".into()),
+                Some(XRPLNetworkErrorKind::Tls),
+            ),
+            (
+                XRPLWebSocketException::Protocol("protocol".into()),
+                Some(XRPLNetworkErrorKind::Protocol),
+            ),
+            (
+                XRPLWebSocketException::InvalidMessage,
+                Some(XRPLNetworkErrorKind::InvalidResponse),
+            ),
+            (
+                XRPLWebSocketException::UnexpectedMessageType,
+                Some(XRPLNetworkErrorKind::InvalidResponse),
+            ),
+            (XRPLWebSocketException::Capacity("capacity".into()), None),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.network_error_kind(), expected);
+        }
+    }
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -286,7 +286,7 @@ mod cli_tests {
     #[test]
     fn test_get_fee() {
         assert_cli_command(
-            &["server", "fee"],
+            &["server", "fee", "--url", constants::TEST_URL],
             "Current network fee:",
             &["Failed to get network fee"],
         );

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -12,3 +12,171 @@ fn it_converts_posix_to_ripple_time() {
 fn it_converts_ripple_time_to_posix() {
     assert_eq!(ripple_time_to_posix(713502659), Ok(1660187459));
 }
+
+#[cfg(all(feature = "std", feature = "json-rpc", feature = "websocket"))]
+mod exception_mapping {
+    use std::error::Error;
+
+    use xrpl::asynch::clients::{
+        exceptions::{XRPLClientException, XRPLNetworkErrorKind},
+        XRPLJsonRpcException, XRPLWebSocketException,
+    };
+
+    #[test]
+    fn maps_websocket_network_error_kinds() {
+        let cases = [
+            (
+                XRPLWebSocketException::Disconnected,
+                Some(XRPLNetworkErrorKind::ConnectionClosed),
+            ),
+            (
+                XRPLWebSocketException::ConnectionClosed,
+                Some(XRPLNetworkErrorKind::ConnectionClosed),
+            ),
+            (
+                XRPLWebSocketException::AlreadyClosed,
+                Some(XRPLNetworkErrorKind::AlreadyClosed),
+            ),
+            (
+                XRPLWebSocketException::TungsteniteIo(std::io::Error::from(
+                    std::io::ErrorKind::ConnectionRefused,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionRefused),
+            ),
+            (
+                XRPLWebSocketException::TungsteniteIo(std::io::Error::from(
+                    std::io::ErrorKind::ConnectionReset,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionReset),
+            ),
+            (
+                XRPLWebSocketException::TungsteniteIo(std::io::Error::from(
+                    std::io::ErrorKind::TimedOut,
+                )),
+                Some(XRPLNetworkErrorKind::TimedOut),
+            ),
+            (
+                XRPLWebSocketException::TungsteniteIo(std::io::Error::from(
+                    std::io::ErrorKind::Other,
+                )),
+                Some(XRPLNetworkErrorKind::OtherIo),
+            ),
+            (
+                XRPLWebSocketException::Tls("tls".into()),
+                Some(XRPLNetworkErrorKind::Tls),
+            ),
+            (
+                XRPLWebSocketException::Protocol("protocol".into()),
+                Some(XRPLNetworkErrorKind::Protocol),
+            ),
+            (
+                XRPLWebSocketException::InvalidMessage,
+                Some(XRPLNetworkErrorKind::InvalidResponse),
+            ),
+            (
+                XRPLWebSocketException::UnexpectedMessageType,
+                Some(XRPLNetworkErrorKind::InvalidResponse),
+            ),
+            (XRPLWebSocketException::Capacity("capacity".into()), None),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.network_error_kind(), expected);
+        }
+    }
+
+    #[test]
+    fn maps_client_network_error_kinds() {
+        let cases = [
+            (
+                XRPLClientException::XRPLWebSocketError(Box::new(
+                    XRPLWebSocketException::ConnectionClosed,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionClosed),
+            ),
+            (
+                XRPLClientException::XRPLJsonRpcError(XRPLJsonRpcException::RequestError(
+                    "not transport".into(),
+                )),
+                None,
+            ),
+            (
+                XRPLClientException::IoError(std::io::Error::from(
+                    std::io::ErrorKind::ConnectionRefused,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionRefused),
+            ),
+            (
+                XRPLClientException::IoError(std::io::Error::from(
+                    std::io::ErrorKind::ConnectionReset,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionReset),
+            ),
+            (
+                XRPLClientException::IoError(std::io::Error::from(std::io::ErrorKind::TimedOut)),
+                Some(XRPLNetworkErrorKind::TimedOut),
+            ),
+            (
+                XRPLClientException::IoError(std::io::Error::from(std::io::ErrorKind::Other)),
+                Some(XRPLNetworkErrorKind::OtherIo),
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.network_error_kind(), expected);
+        }
+    }
+
+    #[test]
+    fn maps_json_rpc_network_error_kinds() {
+        let request_error = XRPLJsonRpcException::RequestError("bad request".into());
+        assert_eq!(request_error.network_error_kind(), None);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let connect_error = runtime.block_on(async {
+            reqwest::get("http://127.0.0.1:1")
+                .await
+                .expect_err("localhost port 1 should refuse connections")
+        });
+        let json_rpc_error = XRPLJsonRpcException::ReqwestError(connect_error);
+        assert_eq!(
+            json_rpc_error.network_error_kind(),
+            Some(XRPLNetworkErrorKind::OtherIo)
+        );
+    }
+
+    #[test]
+    fn converts_tungstenite_errors_to_typed_websocket_errors() {
+        let cases = [
+            (
+                tokio_tungstenite::tungstenite::Error::ConnectionClosed,
+                Some(XRPLNetworkErrorKind::ConnectionClosed),
+            ),
+            (
+                tokio_tungstenite::tungstenite::Error::AlreadyClosed,
+                Some(XRPLNetworkErrorKind::AlreadyClosed),
+            ),
+            (
+                tokio_tungstenite::tungstenite::Error::Io(std::io::Error::from(
+                    std::io::ErrorKind::ConnectionRefused,
+                )),
+                Some(XRPLNetworkErrorKind::ConnectionRefused),
+            ),
+        ];
+
+        for (error, expected) in cases {
+            let error = XRPLWebSocketException::from(error);
+            assert_eq!(error.network_error_kind(), expected);
+        }
+
+        let protocol_error = tokio_tungstenite::tungstenite::Error::Protocol(
+            tokio_tungstenite::tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+        );
+        let protocol_error = XRPLWebSocketException::from(protocol_error);
+        assert_eq!(
+            protocol_error.network_error_kind(),
+            Some(XRPLNetworkErrorKind::Protocol)
+        );
+        assert!(protocol_error.source().is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- add typed client network error categories for async JSON-RPC/WebSocket clients
- map transport errors into XRPLNetworkErrorKind
- add integration-covered tests for exception mapping branches
- stabilize local standalone fee CLI coverage and update Codecov action to v5.5.5

## Local validation
- cargo fmt --all -- --check
- cargo clippy --all-features -- -D warnings
- build matrix from Build & Lint workflow
- cargo test --release
- cargo test --release --no-default-features --features embassy-rt,core,utils,wallet,models,helpers,websocket,json-rpc
- unit cargo-llvm-cov thresholds
- integration cargo-llvm-cov against local xrpld via podman
- clio smoke: cargo run ... server fee --url http://localhost:51233

Integration patch coverage locally: 85.11%.