### PR TITLE
fix(oracle): keep ISO/hex restriction in validate_oracle_currency to prevent sign-time failure

### DIFF
--- a/src/models/transactions/mod.rs
+++ b/src/models/transactions/mod.rs
@@ -768,15 +768,14 @@ fn validate_oracle_currency(
     field: &'static str,
     value: &str,
 ) -> crate::models::XRPLModelResult<()> {
-    if crate::utils::is_iso_code(value) || crate::utils::is_iso_hex(value) {
-        return Ok(());
+    if value.is_empty() {
+        return Err(crate::models::XRPLModelException::InvalidValue {
+            field: field.into(),
+            expected: "a non-empty currency code".into(),
+            found: "(empty string)".into(),
+        });
     }
-    Err(crate::models::XRPLModelException::InvalidValue {
-        field: field.into(),
-        expected: "a 3-character ISO currency code (including \"XRP\") or 40-character hex code"
-            .into(),
-        found: value.into(),
-    })
+    Ok(())
 }
 
 fn validate_oracle_asset_price(value: &Option<String>) -> crate::models::XRPLModelResult<()> {

--- a/src/models/transactions/mod.rs
+++ b/src/models/transactions/mod.rs
@@ -764,18 +764,30 @@ impl crate::models::Model for PriceData {
 /// Maximum allowed value for `AssetPrice`.
 pub const MAX_ORACLE_ASSET_PRICE: u64 = u64::MAX;
 
+/// Validate that an oracle currency code is either a 3-character ISO code (e.g. `XRP`,
+/// `USD`, `BTC`) or a 40-character uppercase hex string.
+///
+/// This mirrors the restriction imposed by [`crate::core::binarycodec::types::currency::Currency::try_from`]:
+/// only 3-char ISO codes and 40-char hex strings can be serialized as a 160-bit Currency
+/// field on the wire.  Arbitrary strings (e.g. `"EURO"`, `"DOGE"`, `"LONGTICKER"`) would
+/// pass a naive non-empty check here but then hard-fail at sign/encode time with
+/// `UnsupportedCurrencyRepresentation`.  xrpl-py applies the same restriction.
+///
+/// If a non-ISO currency identifier is needed, encode it as a 40-char hex string first.
 fn validate_oracle_currency(
     field: &'static str,
     value: &str,
 ) -> crate::models::XRPLModelResult<()> {
-    if value.is_empty() {
-        return Err(crate::models::XRPLModelException::InvalidValue {
-            field: field.into(),
-            expected: "a non-empty currency code".into(),
-            found: "(empty string)".into(),
-        });
+    if crate::utils::is_iso_code(value) || crate::utils::is_iso_hex(value) {
+        return Ok(());
     }
-    Ok(())
+    Err(crate::models::XRPLModelException::InvalidValue {
+        field: field.into(),
+        expected:
+            "a 3-character ISO currency code (e.g. \"XRP\", \"USD\") or 40-character hex code"
+                .into(),
+        found: value.into(),
+    })
 }
 
 fn validate_oracle_asset_price(value: &Option<String>) -> crate::models::XRPLModelResult<()> {

--- a/src/models/transactions/oracle_set.rs
+++ b/src/models/transactions/oracle_set.rs
@@ -701,10 +701,10 @@ mod tests {
     }
 
     #[test]
-    fn test_arbitrary_non_empty_base_asset_accepted() {
-        // rippled imposes no ISO/hex restriction on BaseAsset/QuoteAsset —
-        // any non-empty string is valid (e.g. EURO, BTC, DOGE, AAPL).
-        for code in &["EURO", "BTC", "DOGE", "AAPL", "X", "LONGTICKER"] {
+    fn test_valid_iso_base_asset_accepted() {
+        // 3-character ISO codes are accepted — they can be serialized by
+        // Currency::try_from in the binary codec.
+        for code in &["BTC", "ETH", "EUR"] {
             let oracle_set = OracleSet {
                 common_fields: CommonFields {
                     account: TEST_ACCOUNT.into(),
@@ -722,7 +722,38 @@ mod tests {
 
             assert!(
                 oracle_set.get_errors().is_ok(),
-                "non-empty base_asset {code:?} should be accepted"
+                "3-char ISO base_asset {code:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_invalid_base_asset_rejected() {
+        // Non-ISO, non-hex strings cannot be serialized by Currency::try_from and
+        // must be rejected at validation time to prevent a silent sign/encode failure.
+        for code in &["EURO", "DOGE", "AAPL", "X", "LONGTICKER"] {
+            let oracle_set = OracleSet {
+                common_fields: CommonFields {
+                    account: TEST_ACCOUNT.into(),
+                    transaction_type: TransactionType::OracleSet,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .with_price_data_series(vec![PriceData {
+                base_asset: code.to_string(),
+                quote_asset: "USD".to_string(),
+                asset_price: Some("100".to_string()),
+                scale: Some(1),
+            }]);
+
+            let err = oracle_set.get_errors().unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    XRPLModelException::InvalidValue { ref field, .. } if field == "base_asset"
+                ),
+                "non-ISO/hex base_asset {code:?} should be rejected"
             );
         }
     }

--- a/src/models/transactions/oracle_set.rs
+++ b/src/models/transactions/oracle_set.rs
@@ -701,8 +701,34 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_base_asset_rejected() {
-        // A 4-character code is neither a valid ISO code nor a 40-char hex.
+    fn test_arbitrary_non_empty_base_asset_accepted() {
+        // rippled imposes no ISO/hex restriction on BaseAsset/QuoteAsset —
+        // any non-empty string is valid (e.g. EURO, BTC, DOGE, AAPL).
+        for code in &["EURO", "BTC", "DOGE", "AAPL", "X", "LONGTICKER"] {
+            let oracle_set = OracleSet {
+                common_fields: CommonFields {
+                    account: TEST_ACCOUNT.into(),
+                    transaction_type: TransactionType::OracleSet,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .with_price_data_series(vec![PriceData {
+                base_asset: code.to_string(),
+                quote_asset: "USD".to_string(),
+                asset_price: Some("100".to_string()),
+                scale: Some(1),
+            }]);
+
+            assert!(
+                oracle_set.get_errors().is_ok(),
+                "non-empty base_asset {code:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_empty_base_asset_rejected() {
         let oracle_set = OracleSet {
             common_fields: CommonFields {
                 account: TEST_ACCOUNT.into(),
@@ -712,7 +738,7 @@ mod tests {
             ..Default::default()
         }
         .with_price_data_series(vec![PriceData {
-            base_asset: "EURO".to_string(),
+            base_asset: "".to_string(),
             quote_asset: "USD".to_string(),
             asset_price: Some("100".to_string()), // hex: 256 decimal,
             scale: Some(1),
@@ -722,6 +748,30 @@ mod tests {
         assert!(matches!(
             err,
             XRPLModelException::InvalidValue { ref field, .. } if field == "base_asset"
+        ));
+    }
+
+    #[test]
+    fn test_empty_quote_asset_rejected() {
+        let oracle_set = OracleSet {
+            common_fields: CommonFields {
+                account: TEST_ACCOUNT.into(),
+                transaction_type: TransactionType::OracleSet,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .with_price_data_series(vec![PriceData {
+            base_asset: "XRP".to_string(),
+            quote_asset: "".to_string(),
+            asset_price: Some("100".to_string()),
+            scale: Some(1),
+        }]);
+
+        let err = oracle_set.get_errors().unwrap_err();
+        assert!(matches!(
+            err,
+            XRPLModelException::InvalidValue { ref field, .. } if field == "quote_asset"
         ));
     }
 


### PR DESCRIPTION
## Why

Loosening `validate_oracle_currency` to accept any non-empty string introduced a silent gap: `BaseAsset` and `QuoteAsset` are typed as `Currency` in `definitions.json` and serialized through `Currency::try_from`, which only accepts 3-char ISO codes (e.g. `XRP`, `USD`, `BTC`) or 40-char hex strings. Arbitrary identifiers like `EURO`, `DOGE`, or `LONGTICKER` would pass `get_errors()` then hard-fail at sign/encode time with `UnsupportedCurrencyRepresentation`. xrpl-py enforces the same restriction for the same reason.

Original issue introduced in #156 (9570a0e0).

## What changed

- `validate_oracle_currency` in `src/models/transactions/mod.rs`: restored the `is_iso_code || is_iso_hex` guard with a doc comment explaining the codec constraint and pointing to `Currency::try_from`
- `src/models/transactions/oracle_set.rs`: split the test into:
  - `test_valid_iso_base_asset_accepted` — BTC, ETH, EUR (valid 3-char ISO) are accepted
  - `test_invalid_base_asset_rejected` — EURO, DOGE, AAPL, X, LONGTICKER are rejected with a clear error
  - `test_empty_base_asset_rejected` and `test_empty_quote_asset_rejected` remain (empty strings are also rejected by the restored guard)

## How to validate

```bash
cargo test --lib --features std oracle
```

All 42 oracle tests pass.

## Note

To use a non-ISO currency identifier (e.g. a stock ticker longer than 3 chars), encode it as a 40-char hex string before passing it as `base_asset` / `quote_asset`.