### PR TITLE
fix(binarycodec): propagate error from write_length_encoded instead of panicking

### DIFF
--- a/src/core/binarycodec/binary_wrappers.rs
+++ b/src/core/binarycodec/binary_wrappers.rs
@@ -385,10 +385,10 @@ pub trait Serialization {
     /// use xrpl::core::binarycodec::Serialization;
     ///
     /// let expected: Vec<u8> = [3, 0, 17, 34].to_vec();
-    /// let mut test_bytes: Vec<u8> = [0, 17, 34].to_vec();
+    /// let test_bytes: Vec<u8> = [0, 17, 34].to_vec();
     /// let mut serializer: BinarySerializer = BinarySerializer::new();
     ///
-    /// serializer.write_length_encoded(&mut test_bytes, true).unwrap();
+    /// serializer.write_length_encoded(&test_bytes, true).unwrap();
     /// assert_eq!(expected, serializer);
     /// ```
     fn write_length_encoded(&mut self, value: &[u8], encode_value: bool) -> XRPLCoreResult<&Self>;
@@ -442,15 +442,13 @@ impl Serialization for BinarySerializer {
     }
 
     fn write_length_encoded(&mut self, value: &[u8], encode_value: bool) -> XRPLCoreResult<&Self> {
-        let mut byte_object: Vec<u8> = Vec::new();
-        if encode_value {
-            // write value to byte_object
-            byte_object.extend_from_slice(value);
-        }
-        let length_prefix = _encode_variable_length_prefix(&byte_object.len())?;
+        let length = if encode_value { value.len() } else { 0 };
+        let length_prefix = _encode_variable_length_prefix(&length)?;
 
         self.extend_from_slice(&length_prefix);
-        self.extend_from_slice(&byte_object);
+        if encode_value {
+            self.extend_from_slice(value);
+        }
 
         Ok(self)
     }

--- a/src/core/binarycodec/binary_wrappers.rs
+++ b/src/core/binarycodec/binary_wrappers.rs
@@ -388,10 +388,10 @@ pub trait Serialization {
     /// let mut test_bytes: Vec<u8> = [0, 17, 34].to_vec();
     /// let mut serializer: BinarySerializer = BinarySerializer::new();
     ///
-    /// serializer.write_length_encoded(&mut test_bytes, true);
+    /// serializer.write_length_encoded(&mut test_bytes, true).unwrap();
     /// assert_eq!(expected, serializer);
     /// ```
-    fn write_length_encoded(&mut self, value: &[u8], encode_value: bool) -> &Self;
+    fn write_length_encoded(&mut self, value: &[u8], encode_value: bool) -> XRPLCoreResult<&Self>;
 
     /// Write field and value to the buffer.
     ///
@@ -424,7 +424,7 @@ pub trait Serialization {
     /// let test_bytes: Vec<u8> = [0, 17, 34].to_vec();
     /// let mut serializer: BinarySerializer = BinarySerializer::new();
     ///
-    /// serializer.write_field_and_value(field_instance, &test_bytes, false);
+    /// serializer.write_field_and_value(field_instance, &test_bytes, false).unwrap();
     /// assert_eq!(expected, serializer);
     /// ```
     fn write_field_and_value(
@@ -432,7 +432,7 @@ pub trait Serialization {
         field: FieldInstance,
         value: &[u8],
         is_unl_modify_workaround: bool,
-    ) -> &Self;
+    ) -> XRPLCoreResult<&Self>;
 }
 
 impl Serialization for BinarySerializer {
@@ -441,19 +441,18 @@ impl Serialization for BinarySerializer {
         self
     }
 
-    fn write_length_encoded(&mut self, value: &[u8], encode_value: bool) -> &Self {
+    fn write_length_encoded(&mut self, value: &[u8], encode_value: bool) -> XRPLCoreResult<&Self> {
         let mut byte_object: Vec<u8> = Vec::new();
         if encode_value {
             // write value to byte_object
             byte_object.extend_from_slice(value);
         }
-        // TODO Handle unwrap better
-        let length_prefix = _encode_variable_length_prefix(&byte_object.len()).unwrap();
+        let length_prefix = _encode_variable_length_prefix(&byte_object.len())?;
 
         self.extend_from_slice(&length_prefix);
         self.extend_from_slice(&byte_object);
 
-        self
+        Ok(self)
     }
 
     fn write_field_and_value(
@@ -461,16 +460,16 @@ impl Serialization for BinarySerializer {
         field: FieldInstance,
         value: &[u8],
         is_unl_modify_workaround: bool,
-    ) -> &Self {
+    ) -> XRPLCoreResult<&Self> {
         self.extend_from_slice(&field.header.to_bytes());
 
         if field.is_vl_encoded {
-            self.write_length_encoded(value, !is_unl_modify_workaround);
+            self.write_length_encoded(value, !is_unl_modify_workaround)?;
         } else {
             self.extend_from_slice(value);
         }
 
-        self
+        Ok(self)
     }
 }
 
@@ -1112,7 +1111,9 @@ mod test {
         let test_bytes: Vec<u8> = [0, 17, 34].to_vec();
         let mut serializer: BinarySerializer = BinarySerializer::new();
 
-        serializer.write_field_and_value(field_instance, &test_bytes, false);
+        serializer
+            .write_field_and_value(field_instance, &test_bytes, false)
+            .unwrap();
         assert_eq!(expected, serializer);
     }
 
@@ -1199,7 +1200,9 @@ mod test {
             let blob = (0..case).map(|_| "A2").collect::<String>();
             let mut binary_serializer: BinarySerializer = BinarySerializer::new();
 
-            binary_serializer.write_length_encoded(&hex::decode(blob).expect(""), true);
+            binary_serializer
+                .write_length_encoded(&hex::decode(blob).expect("valid hex"), true)
+                .unwrap();
 
             let mut binary_parser: BinaryParser = BinaryParser::from(binary_serializer.as_ref());
             let decoded_length = binary_parser.read_length_prefix();
@@ -1207,5 +1210,25 @@ mod test {
             assert!(decoded_length.is_ok());
             assert_eq!(decoded_length, Ok(case));
         }
+    }
+
+    /// Regression test for #268: `write_length_encoded` must return `Err` when the
+    /// value exceeds `MAX_LENGTH_VALUE` instead of panicking via `.unwrap()`.
+    #[test]
+    fn test_write_length_encoded_too_large_returns_error() {
+        let big = vec![0u8; MAX_LENGTH_VALUE + 1];
+        let mut serializer: BinarySerializer = BinarySerializer::new();
+        let result = serializer.write_length_encoded(&big, true);
+
+        assert!(
+            matches!(
+                result,
+                Err(XRPLCoreException::XRPLBinaryCodecError(
+                    XRPLBinaryCodecException::InvalidVariableLengthTooLarge { max }
+                )) if max == MAX_LENGTH_VALUE
+            ),
+            "Expected InvalidVariableLengthTooLarge error, got: {:?}",
+            result
+        );
     }
 }

--- a/src/core/binarycodec/types/mod.rs
+++ b/src/core/binarycodec/types/mod.rs
@@ -606,7 +606,7 @@ impl STObject {
                 field_instance.to_owned(),
                 associated_value.as_ref(),
                 is_unl_modify_workaround,
-            );
+            )?;
             if field_instance.associated_type == ST_OBJECT {
                 serializer.append(OBJECT_END_MARKER_BYTES.to_vec().as_mut());
             }


### PR DESCRIPTION
## Why

`BinarySerializer::write_length_encoded` returned `&Self` (infallible) and called `_encode_variable_length_prefix(...).unwrap()`. When a caller serialized a VL-encoded field larger than `MAX_LENGTH_VALUE` (918,744 bytes), this panicked instead of returning an error. The method contained a `// TODO Handle unwrap better` comment acknowledging the gap.

Fixes #268.

## What changed

- `write_length_encoded` and `write_field_and_value` signatures changed from `-> &Self` to `-> XRPLCoreResult<&Self>`.
- `.unwrap()` replaced with `?`; callers updated to propagate with `?`.
- Doc examples updated to call `.unwrap()` in the example context.

## How to validate

```
cargo test --release
```

Regression test `test_write_length_encoded_too_large_returns_error` verifies `Err(InvalidVariableLengthTooLarge { max: 918744 })` is returned instead of a panic.

**Note:** `Serialization` is a `pub` trait; this is a breaking API change. Downstream crates implementing the trait must update their signatures. Recommend a version bump.