### PR TITLE
fix(binarycodec): guard BinaryParser::read bounds + limit STObject decode depth

### DIFF
--- a/src/core/binarycodec/binary_wrappers.rs
+++ b/src/core/binarycodec/binary_wrappers.rs
@@ -498,8 +498,14 @@ impl Parser for BinaryParser {
     }
 
     fn read(&mut self, n: usize) -> XRPLCoreResult<Vec<u8>> {
+        if n > self.0.len() {
+            return Err(XRPLBinaryCodecException::UnexpectedParserSkipOverflow {
+                max: self.0.len(),
+                found: n,
+            }
+            .into());
+        }
         let first_n_bytes = self.0[..n].to_owned();
-
         self.skip_bytes(n)?;
         Ok(first_n_bytes)
     }
@@ -694,6 +700,11 @@ pub(crate) const TRANSACTION_MULTISIG_PREFIX: [u8; 4] = (0x534D5400u32).to_be_by
 pub(crate) const PAYMENT_CHANNEL_CLAIM_PREFIX: [u8; 4] = (0x434C4D00u32).to_be_bytes();
 pub(crate) const BATCH_PREFIX: [u8; 4] = (0x42434800u32).to_be_bytes();
 
+/// Maximum allowed STObject/STArray nesting depth during binary decoding.
+/// Exceeding this limit returns an error rather than recursing further,
+/// preventing stack exhaustion from crafted deeply-nested payloads.
+const MAX_DECODE_DEPTH: u32 = 32;
+
 /// UInt64 fields that should be encoded/decoded as base-10 strings instead of hex.
 pub(crate) const BASE10_UINT64_FIELDS: &[&str] = &[
     "MaximumAmount",
@@ -732,7 +743,11 @@ where
 
 /// Decode a single field value from a BinaryParser based on the field's type.
 /// Returns the JSON value for the field.
-fn decode_field_value(parser: &mut BinaryParser, field: &FieldInstance) -> XRPLCoreResult<Value> {
+fn decode_field_value(
+    parser: &mut BinaryParser,
+    field: &FieldInstance,
+    depth: u32,
+) -> XRPLCoreResult<Value> {
     let type_name = field.associated_type.as_str();
 
     // Handle VL prefix for variable-length encoded fields
@@ -835,8 +850,8 @@ fn decode_field_value(parser: &mut BinaryParser, field: &FieldInstance) -> XRPLC
             );
             Ok(Value::Number(val.into()))
         }
-        "STObject" => decode_st_object(parser),
-        "STArray" => decode_st_array(parser),
+        "STObject" => decode_st_object(parser, depth + 1),
+        "STArray" => decode_st_array(parser, depth + 1),
         "PathSet" => {
             let path_set = PathSet::from_parser(parser, length)?;
             Ok(serde_json::to_value(&path_set).map_err(XRPLSerdeJsonError::from)?)
@@ -877,7 +892,17 @@ fn decode_field_value(parser: &mut BinaryParser, field: &FieldInstance) -> XRPLC
 
 /// Decode an STObject from the parser. Reads fields until ObjectEndMarker (0xE1)
 /// or end of parser data.
-pub(crate) fn decode_st_object(parser: &mut BinaryParser) -> XRPLCoreResult<Value> {
+///
+/// `depth` tracks the current nesting level. Returns an error when `depth`
+/// exceeds `MAX_DECODE_DEPTH` to prevent stack exhaustion from crafted payloads.
+pub(crate) fn decode_st_object(parser: &mut BinaryParser, depth: u32) -> XRPLCoreResult<Value> {
+    if depth > MAX_DECODE_DEPTH {
+        return Err(XRPLBinaryCodecException::MaxDecodeDepthExceeded {
+            max: MAX_DECODE_DEPTH,
+        }
+        .into());
+    }
+
     let mut accumulator = Map::new();
 
     while !parser.is_end(None) {
@@ -887,7 +912,7 @@ pub(crate) fn decode_st_object(parser: &mut BinaryParser) -> XRPLCoreResult<Valu
             break;
         }
 
-        let value = decode_field_value(parser, &field)?;
+        let value = decode_field_value(parser, &field, depth)?;
         accumulator.insert(field.name, value);
     }
 
@@ -896,7 +921,7 @@ pub(crate) fn decode_st_object(parser: &mut BinaryParser) -> XRPLCoreResult<Valu
 
 /// Decode an STArray from the parser. Reads wrapper objects until
 /// ArrayEndMarker (0xF1) or end of parser data.
-fn decode_st_array(parser: &mut BinaryParser) -> XRPLCoreResult<Value> {
+fn decode_st_array(parser: &mut BinaryParser, depth: u32) -> XRPLCoreResult<Value> {
     let mut result: Vec<Value> = Vec::new();
 
     while !parser.is_end(None) {
@@ -906,7 +931,7 @@ fn decode_st_array(parser: &mut BinaryParser) -> XRPLCoreResult<Value> {
             break;
         }
 
-        let inner = decode_st_object(parser)?;
+        let inner = decode_st_object(parser, depth + 1)?;
         let mut wrapper = Map::new();
         wrapper.insert(field.name, inner);
         result.push(Value::Object(wrapper));
@@ -1138,7 +1163,7 @@ mod test {
         let field = FieldInstance::new(&field_info, "FutureField", field_header);
 
         let mut parser = BinaryParser::from(&[0xAB, 0xCD][..]);
-        let result = decode_field_value(&mut parser, &field);
+        let result = decode_field_value(&mut parser, &field, 0);
 
         assert!(
             result.is_err(),
@@ -1180,7 +1205,7 @@ mod test {
 
         // VL prefix 0x03 = 3 bytes, followed by 3 bytes of data
         let mut parser = BinaryParser::from(&[0x03, 0xAA, 0xBB, 0xCC][..]);
-        let result = decode_field_value(&mut parser, &field);
+        let result = decode_field_value(&mut parser, &field, 0);
 
         assert!(result.is_ok(), "VL-encoded unknown type should succeed");
         assert_eq!(
@@ -1188,6 +1213,64 @@ mod test {
             serde_json::Value::String("AABBCC".to_string())
         );
         assert!(parser.0.is_empty(), "Parser should have consumed all bytes");
+    }
+
+    /// Regression test for OOBIDX-001: read() must return Err when n > buffer
+    /// length rather than panicking with an out-of-bounds slice.
+    #[test]
+    fn test_binary_parser_read_truncated_returns_error() {
+        let data = vec![0x01u8, 0x02];
+        let mut parser = BinaryParser::from(data.as_slice());
+        let result = parser.read(10);
+        assert!(
+            result.is_err(),
+            "read() must return Err on truncated input, not panic"
+        );
+        // Confirm it's specifically an overflow error, not a different failure mode.
+        match result.unwrap_err() {
+            XRPLCoreException::XRPLBinaryCodecError(
+                XRPLBinaryCodecException::UnexpectedParserSkipOverflow { max, found },
+            ) => {
+                assert_eq!(max, 2);
+                assert_eq!(found, 10);
+            }
+            e => panic!("expected UnexpectedParserSkipOverflow, got: {:?}", e),
+        }
+    }
+
+    /// Regression test for RECURSEDES-001: deeply nested STObject payloads must
+    /// return Err(MaxDecodeDepthExceeded) rather than causing a stack overflow.
+    ///
+    /// The binary format for an STObject field uses the XRPL type-field header:
+    ///   type_code = 14 (STObject), field_code = 7 (FinalFields) → byte 0xE7
+    /// Each 0xE7 byte triggers a recursive call to decode_st_object. After
+    /// MAX_DECODE_DEPTH+1 levels the guard fires and returns an error.
+    #[test]
+    fn test_decode_st_object_depth_limit() {
+        // FinalFields: type=14 (STObject), nth=7 → (14 << 4) | 7 = 0xE7
+        // ObjectEndMarker: type=14, nth=1 → 0xE1 (terminates each level)
+        let levels = MAX_DECODE_DEPTH + 2;
+        let mut blob = Vec::new();
+        for _ in 0..levels {
+            blob.push(0xE7u8); // FinalFields field header (associated_type = STObject)
+        }
+        for _ in 0..levels {
+            blob.push(0xE1u8); // ObjectEndMarker
+        }
+        let hex_input = hex::encode(&blob);
+        let result = crate::core::binarycodec::decode(&hex_input);
+        match result {
+            Err(XRPLCoreException::XRPLBinaryCodecError(
+                XRPLBinaryCodecException::MaxDecodeDepthExceeded { max },
+            )) => {
+                assert_eq!(
+                    max, MAX_DECODE_DEPTH,
+                    "depth limit value should match constant"
+                );
+            }
+            Err(e) => panic!("expected MaxDecodeDepthExceeded, got: {:?}", e),
+            Ok(_) => panic!("deeply nested STObject must return Err, not Ok"),
+        }
     }
 
     /// This is currently a sanity check for private

--- a/src/core/binarycodec/exceptions.rs
+++ b/src/core/binarycodec/exceptions.rs
@@ -24,6 +24,8 @@ pub enum XRPLBinaryCodecException {
     InvalidReadFromBytesValue,
     #[error("Invalid variable length too large: max: {max}")]
     InvalidVariableLengthTooLarge { max: usize },
+    #[error("Max decode depth exceeded: max: {max}")]
+    MaxDecodeDepthExceeded { max: u32 },
     #[error("Invalid hash length (expected: {expected}, found: {found})")]
     InvalidHashLength { expected: usize, found: usize },
     #[error("Invalid path set from value")]

--- a/src/core/binarycodec/mod.rs
+++ b/src/core/binarycodec/mod.rs
@@ -154,7 +154,7 @@ pub fn encode_for_signing_batch(flags: u32, tx_ids: &[&str]) -> XRPLCoreResult<S
 /// JSON representation as a `serde_json::Value`.
 pub fn decode(hex_string: &str) -> XRPLCoreResult<Value> {
     let mut parser = BinaryParser::try_from(hex_string)?;
-    decode_st_object(&mut parser)
+    decode_st_object(&mut parser, 0)
 }
 
 /// Decode a serialized ledger header from hex into JSON.


### PR DESCRIPTION
## Why

`BinaryParser::read(n)` sliced `self.0[..n]` before calling `skip_bytes(n)`, which is where the bounds check lived. On a truncated binary XRPL blob, `read` panicked instead of returning an error — reachable from any network-sourced binary data via `decode()`.

`decode_st_object` and `decode_field_value` form a mutually recursive pair with no depth limit. A crafted binary blob embedding deeply nested STObject headers (~4–16 KB) overflows the stack. Stack overflows abort the process unconditionally — they are not catchable with `catch_unwind`.

## What changed

- `BinaryParser::read`: added `if n > self.0.len()` guard returning `UnexpectedParserSkipOverflow { max, found }` before the slice.
- Added `const MAX_DECODE_DEPTH: u32 = 32`.
- Added `MaxDecodeDepthExceeded { max: u32 }` variant to `XRPLBinaryCodecException`.
- `decode_st_object`, `decode_field_value`, `decode_st_array` now accept a `depth: u32` parameter; the public `decode()` entry passes `depth: 0`.
- `decode_st_object` returns `Err(MaxDecodeDepthExceeded)` when `depth > MAX_DECODE_DEPTH`.

## How to validate

```
cargo test --release
```

New tests: `test_binary_parser_read_truncated_returns_error`, `test_decode_st_object_depth_limit`.