### PR TITLE
fix(models): make XRPAmount and IssuedCurrencyAmount Ord consistent with PartialEq

### DIFF
--- a/src/models/amount/issued_currency_amount.rs
+++ b/src/models/amount/issued_currency_amount.rs
@@ -47,6 +47,18 @@ impl<'a> PartialOrd for IssuedCurrencyAmount<'a> {
 
 impl<'a> Ord for IssuedCurrencyAmount<'a> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.value.cmp(&other.value)
+        // Compare numerically when both values parse; fall back to string order.
+        // Then break ties with currency and issuer so that Ord is consistent
+        // with the derived PartialEq (which compares all three fields).
+        let value_cmp = match (
+            self.value.parse::<BigDecimal>(),
+            other.value.parse::<BigDecimal>(),
+        ) {
+            (Ok(a), Ok(b)) => a.partial_cmp(&b).unwrap_or(core::cmp::Ordering::Equal),
+            _ => self.value.cmp(&other.value),
+        };
+        value_cmp
+            .then_with(|| self.currency.cmp(&other.currency))
+            .then_with(|| self.issuer.cmp(&other.issuer))
     }
 }

--- a/src/models/amount/xrp_amount.rs
+++ b/src/models/amount/xrp_amount.rs
@@ -164,8 +164,11 @@ impl<'a> PartialOrd for XRPAmount<'a> {
 
 impl<'a> Ord for XRPAmount<'a> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        // Fall back to lexicographic string comparison when either value is
+        // non-numeric (e.g. malformed server response). This keeps Ord total
+        // and non-panicking while still being numerically correct for valid drops.
         self.checked_cmp(other)
-            .expect("cannot compare invalid XRPAmount values")
+            .unwrap_or_else(|_| self.0.cmp(&other.0))
     }
 }
 
@@ -213,12 +216,17 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot compare invalid XRPAmount values")]
-    fn test_cmp_panics_on_malformed() {
+    fn test_cmp_malformed_falls_back_to_lexicographic() {
+        // cmp must not panic on non-numeric values; it falls back to
+        // lexicographic string comparison for a consistent total order.
         let valid = XRPAmount("100".into());
         let malformed = XRPAmount("xyz".into());
 
+        // Must not panic — result is determined by string order
         let _ = valid.cmp(&malformed);
+
+        // Reflexivity: same non-numeric string compares equal to itself
+        assert_eq!(malformed.cmp(&malformed), Ordering::Equal);
     }
 
     #[test]


### PR DESCRIPTION
## Why

`XRPAmount::cmp` called `.expect("cannot compare invalid XRPAmount values")`, which panicked when the inner string was non-numeric (e.g. from a malformed server fee response). `check_txn_fee`, called by `autofill` and `sign_and_submit`, uses `>` on `XRPAmount` and would crash on any non-numeric fee value returned from a connected node.

`IssuedCurrencyAmount::cmp` compared only the `value` field while `PartialEq` compared all three fields (`currency`, `issuer`, `value`). This violated the `Ord`/`Eq` contract: two amounts with the same value but different issuers were `Ord`-equal but `PartialEq`-unequal, causing silent data loss when these values were used as `BTreeMap` keys.

## What changed

- `XRPAmount::cmp`: replaced `.expect(...)` with `.unwrap_or_else(|_| self.0.cmp(&other.0))` — falls back to lexicographic comparison for non-numeric values instead of panicking.
- `IssuedCurrencyAmount::cmp`: now compares all three fields (numeric value, then currency, then issuer), consistent with `PartialEq`.

## How to validate

```
cargo test --release
```