### PR TITLE
chore: declare rust-version = 1.87 MSRV and add deny(unsafe_code) lint gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xrpl-rust"
 version = "1.2.0"
 edition = "2021"
+rust-version = "1.87"
 authors = [
     "Tanveer Wahid <tan@wahid.email>",
     "LimpidCrypto <contact@limpidcrypto.com>",
@@ -165,3 +166,6 @@ actix-rt = ["dep:actix-rt"]
 async-std-rt = ["dep:async-std"]
 futures-rt = ["dep:futures-timer"]
 smol-rt = ["dep:smol"]
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //!
 //! For the user guide and further documentation, please read
 //! [XRP Ledger](https://xrpl.org/docs.html).
+#![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)] // Remove eventually
 #![allow(clippy::result_large_err)]

--- a/xrpl-rust-macros/Cargo.toml
+++ b/xrpl-rust-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xrpl-rust-macros"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.87"
 description = "XRPL Rust Macros"
 license = "ISC"
 


### PR DESCRIPTION
## Why

The crate had no declared `rust-version`, making it unclear which Rust toolchain is required. The effective minimum is 1.87 (driven by `usize::is_multiple_of`, stable in 1.87, used in multiple files; `edition = "2024"` in `xrpl-rust-macros` requires ≥ 1.85).

Without a `deny(unsafe_code)` lint, there is no CI barrier against future introduction of `unsafe` blocks into a crate that currently contains none.

## What changed

- `Cargo.toml` and `xrpl-rust-macros/Cargo.toml`: added `rust-version = "1.87"` to `[package]`.
- `Cargo.toml`: added `[lints.rust] unsafe_code = "forbid"`.
- `src/lib.rs`: added `#![forbid(unsafe_code)]` as first crate attribute.

## How to validate

```
cargo build --release
cargo clippy --all-features -- -D warnings
```