### PR TITLE
chore: declare rust-version and forbid unsafe_code in manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,5 @@ async-std-rt = ["dep:async-std"]
 futures-rt = ["dep:futures-timer"]
 smol-rt = ["dep:smol"]
 
-
 [lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xrpl-rust"
 version = "1.2.0"
 edition = "2021"
+rust-version = "1.87"
 authors = [
     "Tanveer Wahid <tan@wahid.email>",
     "LimpidCrypto <contact@limpidcrypto.com>",
@@ -165,3 +166,7 @@ actix-rt = ["dep:actix-rt"]
 async-std-rt = ["dep:async-std"]
 futures-rt = ["dep:futures-timer"]
 smol-rt = ["dep:smol"]
+
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/xrpl-rust-macros/Cargo.toml
+++ b/xrpl-rust-macros/Cargo.toml
@@ -13,3 +13,6 @@ proc-macro = true
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/xrpl-rust-macros/Cargo.toml
+++ b/xrpl-rust-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xrpl-rust-macros"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 description = "XRPL Rust Macros"
 license = "ISC"
 


### PR DESCRIPTION
## Why

Two hardening gaps were identified in the manifest files:

1. **No declared MSRV** — `Cargo.toml` had no `rust-version` field, so the documented MSRV of 1.87 was unenforced. `xrpl-rust-macros` uses `edition = "2024"` (requires Rust ≥ 1.85) with no corresponding guard. Downstream users on older toolchains received cryptic proc-macro errors instead of a clear MSRV message. Closes #351.

2. **No `unsafe_code` lint guard** — The crate contains no `unsafe` blocks, but without `forbid(unsafe_code)` nothing prevents a future contribution from silently adding raw pointer operations into deserialization paths that process untrusted XRPL network data. Closes #350.

## What changed

- `Cargo.toml`: added `rust-version = "1.87"` and `[lints.rust] unsafe_code = "forbid"`
- `xrpl-rust-macros/Cargo.toml`: added `rust-version = "1.85"` (matches `edition = "2024"` requirement)

## How to validate

```bash
# MSRV guard works
rustup toolchain install 1.86
cargo +1.86 check 2>&1 | grep "rust-version"
# → error: package `xrpl-rust v1.2.0` cannot be built because it requires rustc >= 1.87.0

# unsafe_code guard works
# Add `unsafe { }` anywhere in src/ and verify:
# → error: usage of an `unsafe` block

# Normal build still works
cargo check --all-features
cargo clippy --all-features -- -D warnings
```