### PR TITLE
fix(models): distinguish DepositPreauth validation errors in ledger_entry request

### DIFF
--- a/src/models/requests/ledger_entry.rs
+++ b/src/models/requests/ledger_entry.rs
@@ -56,16 +56,19 @@ impl Model for DepositPreauth<'_> {
                                 .credential_type
                                 .eq_ignore_ascii_case(&credential.credential_type)
                     }) {
-                        return Err(XRPLModelException::InvalidValue {
-                            field: "authorized_credentials".into(),
-                            expected: "unique issuer and credential_type pairs".into(),
-                            found: credential.credential_type.to_string(),
+                        return Err(XRPLModelException::ValueEqualsValue {
+                            field1: "authorized_credentials".into(),
+                            field2: "authorized_credentials (duplicate entry)".into(),
                         });
                     }
                 }
                 Ok(())
             }
-            _ => Err(XRPLModelException::ExpectedOneOf(&[
+            (Some(_), Some(_)) => Err(XRPLModelException::InvalidFieldCombination {
+                field: "authorized",
+                other_fields: &["authorized_credentials"],
+            }),
+            (None, None) => Err(XRPLModelException::ExpectedOneOf(&[
                 "authorized",
                 "authorized_credentials",
             ])),
@@ -652,7 +655,13 @@ mod test_ledger_entry_errors {
             ..Default::default()
         };
 
-        assert!(req.validate().is_err());
+        assert_eq!(
+            req.validate().unwrap_err(),
+            XRPLModelException::ValueEqualsValue {
+                field1: "authorized_credentials".into(),
+                field2: "authorized_credentials (duplicate entry)".into(),
+            }
+        );
     }
 
     #[test]
@@ -676,7 +685,13 @@ mod test_ledger_entry_errors {
             ..Default::default()
         };
 
-        assert!(req.validate().is_err());
+        assert_eq!(
+            req.validate().unwrap_err(),
+            XRPLModelException::ValueEqualsValue {
+                field1: "authorized_credentials".into(),
+                field2: "authorized_credentials (duplicate entry)".into(),
+            }
+        );
     }
 
     #[test]
@@ -693,7 +708,30 @@ mod test_ledger_entry_errors {
             ..Default::default()
         };
 
-        assert!(req.validate().is_err());
+        assert_eq!(
+            req.validate().unwrap_err(),
+            XRPLModelException::InvalidFieldCombination {
+                field: "authorized",
+                other_fields: &["authorized_credentials"],
+            }
+        );
+    }
+
+    #[test]
+    fn test_deposit_preauth_rejects_neither_authorized_nor_credentials() {
+        let req = LedgerEntry {
+            deposit_preauth: Some(DepositPreauth {
+                owner: "rOwner".into(),
+                authorized: None,
+                authorized_credentials: None,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            req.validate().unwrap_err(),
+            XRPLModelException::ExpectedOneOf(&["authorized", "authorized_credentials"])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## High Level Overview of Change

Fixes two related validation bugs in `DepositPreauth::get_errors()` (the `ledger_entry` request selector, `src/models/requests/ledger_entry.rs`):

1. The catch-all match arm returned the same `ExpectedOneOf` error for both "neither `authorized` nor `authorized_credentials` set" and "both set" — two states that need opposite remediation (add a field vs. remove one). These are now split into distinct arms.
2. Duplicate entries in `authorized_credentials` raised `InvalidValue`, while every other site in the codebase that detects duplicate credentials (`validate_credential_ids`, the `DepositPreauth` transaction model, the `DepositPreauth` ledger object model) raises `ValueEqualsValue`. Callers that match on `ValueEqualsValue` to categorize "duplicate credential" errors silently fell through to their default arm for this one request type.

### Context of Change

Both inconsistencies were found during review of #154 (XLS-70 Credentials support); neither was introduced by that PR. Filed as #333 and #334.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests

## Before / After

| Input | Before | After |
|---|---|---|
| `authorized: None, authorized_credentials: None` | `ExpectedOneOf(["authorized", "authorized_credentials"])` | unchanged |
| `authorized: Some, authorized_credentials: Some` | `ExpectedOneOf(["authorized", "authorized_credentials"])` | `InvalidFieldCombination { field: "authorized", other_fields: ["authorized_credentials"] }` |
| duplicate `(issuer, credential_type)` pair in `authorized_credentials` | `InvalidValue { field: "authorized_credentials", expected: "unique issuer and credential_type pairs", .. }` | `ValueEqualsValue { field1: "authorized_credentials", field2: "authorized_credentials (duplicate entry)" }`, matching every other duplicate-credential check in the codebase |

`InvalidFieldCombination` was chosen over `ValueEqualsValue` for the mutually-exclusive-fields case because `ValueEqualsValue` is used elsewhere in this codebase strictly for "these two fields hold the same value" (e.g. `account == authorize`), not "these two fields are both present" — `InvalidFieldCombination` already carries that second meaning at the sibling ledger-object and transaction validators.

## Test Plan

`cargo test --release` (1314 passed, up from 1313). Updated `test_deposit_preauth_rejects_duplicate_authorized_credentials`, `test_deposit_preauth_rejects_case_variant_duplicate_credentials`, and `test_deposit_preauth_rejects_authorized_and_credentials` to assert on the specific error variant instead of only `is_err()`. Added `test_deposit_preauth_rejects_neither_authorized_nor_credentials`, which previously had no coverage.

`cargo clippy --all-targets` and `cargo fmt --check` are clean on the changed file.

Closes #333
Closes #334
