### PR TITLE
fix(signing): decouple multisign's tx_list borrow from Transaction's lifetime

### DIFF
--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -82,7 +82,7 @@ where
 /// Combine signer-signed copies of `transaction` into a single multisigned
 /// transaction. `tx_list` must contain copies of `transaction` each signed by
 /// a different signer.
-pub fn multisign<'a, T, F>(transaction: &mut T, tx_list: &'a Vec<T>) -> XRPLHelperResult<()>
+pub fn multisign<'a, 'b, T, F>(transaction: &mut T, tx_list: &'b [T]) -> XRPLHelperResult<()>
 where
     F: IntoEnumIterator + Serialize + Debug + PartialEq + 'a,
     T: Transaction<'a, F>,

--- a/tests/transactions/multisign_payment.rs
+++ b/tests/transactions/multisign_payment.rs
@@ -61,14 +61,8 @@ async fn test_multisign_payment() {
         sign(&mut payment_signed_by_b, &signer_b, true).expect("signer B sign");
 
         // multisign() merges the signer-signed copies into the master transaction.
-        // Box::leak the Vec because multisign's signature ties the borrow's lifetime
-        // to T's 'a parameter, which the async block infers as 'static when the
-        // Payment was built from string literals (e.g. XRPAmount::from("20000000")).
-        // Without 'static here the borrow checker rejects the call. The leak is
-        // intentional and bounded by the test runtime.
-        let signer_signed_copies: &'static Vec<_> =
-            Box::leak(Box::new(vec![payment_signed_by_a, payment_signed_by_b]));
-        xrpl::transaction::multisign(&mut payment, signer_signed_copies)
+        let signer_signed_copies = vec![payment_signed_by_a, payment_signed_by_b];
+        xrpl::transaction::multisign(&mut payment, &signer_signed_copies)
             .expect("multisign combine");
 
         assert!(


### PR DESCRIPTION
## High Level Overview of Change

`multisign`'s signature conflated two independent lifetimes under one parameter `'a`: the borrow lifetime of `tx_list` and `T`'s own `Transaction<'a, F>` data lifetime. Whenever a caller's `T` got inferred as `'static` (routine when a transaction is built from string literals inside an async block), the borrow of `tx_list` was forced to `'static` too, leaving `Box::leak` as the only way to call the function. Implements Option A from #306: give the borrow its own lifetime and take a slice instead of `&Vec<T>`.

```rust
// before
pub fn multisign<'a, T, F>(transaction: &mut T, tx_list: &'a Vec<T>) -> XRPLHelperResult<()>

// after
pub fn multisign<'a, 'b, T, F>(transaction: &mut T, tx_list: &'b [T]) -> XRPLHelperResult<()>
```

`'b` is the short borrow lifetime; `'a` remains `T`'s own data lifetime, now free to be inferred independently. The function body only iterates `tx_list` once and clones out each tx's first signer — it never stores the reference past the call, so a short, independent borrow is sufficient. `&Vec<T>` → `&[T]` is also more idiomatic and existing `&vec` call sites keep working via the standard slice coercion.

### Context of Change

Filed as #306 after `Box::leak` showed up as the only way to satisfy the borrow checker in the multisign integration test added by #298.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

`tests/transactions/multisign_payment.rs` previously had to leak the signer-signed-copies `Vec` to get a `&'static Vec<_>`:

```rust
let signer_signed_copies: &'static Vec<_> =
    Box::leak(Box::new(vec![payment_signed_by_a, payment_signed_by_b]));
xrpl::transaction::multisign(&mut payment, signer_signed_copies)
```

Now it's a plain local borrow:

```rust
let signer_signed_copies = vec![payment_signed_by_a, payment_signed_by_b];
xrpl::transaction::multisign(&mut payment, &signer_signed_copies)
```

## Test Plan

- `cargo test --release`: 1314 passed, including the existing unit test in `src/transaction/multisign.rs::test`.
- `cargo check --tests --features std,json-rpc,helpers,cli,websocket,integration`: compiles clean, confirming `tests/transactions/multisign_payment.rs` no longer needs `Box::leak` and matches CI's feature set (this test requires a live `xrpld` node to actually execute, so it wasn't run end-to-end here — only compiled).
- `cargo clippy --all-targets --features std,json-rpc,helpers,cli,websocket,integration` and `cargo fmt --check`: clean on both changed files.

Closes #306
