### PR TITLE
ci: add quarterly Dependabot scan for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: quarterly
+      time: "15:00"
+    open-pull-requests-limit: 30
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: quarterly
+      time: "15:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## High Level Overview of Change

Adds `.github/dependabot.yml`, configuring a quarterly Dependabot scan for both dependency surfaces in this repo: `cargo` (the crate's own dependencies, declared in `Cargo.toml`) and `github-actions` (the workflow files under `.github/workflows/`).

### Context of Change

Requested in #295, which points to xrpl-py's existing Dependabot config as the pattern to follow (`interval: quarterly`, `time: "15:00"`, `open-pull-requests-limit: 30`) — xrpl-py uses `pip` as its ecosystem; the Rust equivalent is `cargo`. `github-actions` is added alongside it since this repo has its own CI workflows with pinned action versions, and Dependabot is the mechanism that keeps those bump PRs flowing automatically.

### Type of Change

- [x] New feature (CI/dependency hygiene)

## Before / After

**Before:** no `.github/dependabot.yml` — dependency and Action-version updates are entirely manual.

**After:**
```yaml
version: 2
updates:
  - package-ecosystem: cargo
    directory: "/"
    schedule:
      interval: quarterly
      time: "15:00"
    open-pull-requests-limit: 30
  - package-ecosystem: github-actions
    directory: "/"
    schedule:
      interval: quarterly
      time: "15:00"
    open-pull-requests-limit: 10
```

`open-pull-requests-limit` is lower for `github-actions` (10 vs. 30) since this repo has only four workflow files and far fewer action references than crate dependencies.

## Test Plan

Validated the YAML parses and matches the [Dependabot configuration schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) (`version: 2`, valid `package-ecosystem` values, correctly nested `schedule`). This is a config-only change — no code, no `cargo test` impact.

Closes #295
