### PR TITLE
feat(models): type ledger_entry response node using LedgerEntry enum

### DIFF
--- a/src/models/ledger/objects/mod.rs
+++ b/src/models/ledger/objects/mod.rs
@@ -54,6 +54,7 @@ use strum::IntoEnumIterator;
 
 use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use serde_with::skip_serializing_none;
 use strum_macros::Display;
 use ticket::Ticket;
@@ -95,7 +96,15 @@ pub enum LedgerEntryType {
     XChainOwnedCreateAccountClaimID = 0x0074,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A ledger object, as returned inline by `ledger` (full/accounts) and `ledger_entry`.
+///
+/// The XRPL wire format for these is a flat JSON object carrying its own
+/// `LedgerEntryType` discriminator field (e.g. `{"LedgerEntryType": "AccountRoot",
+/// "Account": ..., ...}`), not serde's default externally-tagged representation
+/// (`{"AccountRoot": {...}}`). `Serialize`/`Deserialize` are implemented by hand
+/// below to match that wire format: deserialization reads `LedgerEntryType` to pick
+/// the variant, and serialization flattens straight through to the inner type.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LedgerEntry<'a> {
     AccountRoot(AccountRoot<'a>),
     Amendments(Amendments<'a>),
@@ -124,6 +133,129 @@ pub enum LedgerEntry<'a> {
     Vault(Vault<'a>),
     XChainOwnedClaimID(XChainOwnedClaimID<'a>),
     XChainOwnedCreateAccountClaimID(XChainOwnedCreateAccountClaimID<'a>),
+}
+
+const LEDGER_ENTRY_TYPE_VARIANTS: &[&str] = &[
+    "AccountRoot",
+    "Amendments",
+    "AMM",
+    "Bridge",
+    "Check",
+    "DID",
+    "Credential",
+    "DepositPreauth",
+    "DirectoryNode",
+    "Escrow",
+    "FeeSettings",
+    "LedgerHashes",
+    "MPToken",
+    "MPTokenIssuance",
+    "NegativeUNL",
+    "NFTokenOffer",
+    "NFTokenPage",
+    "Offer",
+    "Oracle",
+    "PayChannel",
+    "PermissionedDomain",
+    "RippleState",
+    "SignerList",
+    "Ticket",
+    "Vault",
+    "XChainOwnedClaimID",
+    "XChainOwnedCreateAccountClaimID",
+];
+
+impl<'a> Serialize for LedgerEntry<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            LedgerEntry::AccountRoot(inner) => inner.serialize(serializer),
+            LedgerEntry::Amendments(inner) => inner.serialize(serializer),
+            LedgerEntry::AMM(inner) => inner.serialize(serializer),
+            LedgerEntry::Bridge(inner) => inner.serialize(serializer),
+            LedgerEntry::Check(inner) => inner.serialize(serializer),
+            LedgerEntry::DID(inner) => inner.serialize(serializer),
+            LedgerEntry::Credential(inner) => inner.serialize(serializer),
+            LedgerEntry::DepositPreauth(inner) => inner.serialize(serializer),
+            LedgerEntry::DirectoryNode(inner) => inner.serialize(serializer),
+            LedgerEntry::Escrow(inner) => inner.serialize(serializer),
+            LedgerEntry::FeeSettings(inner) => inner.serialize(serializer),
+            LedgerEntry::LedgerHashes(inner) => inner.serialize(serializer),
+            LedgerEntry::MPToken(inner) => inner.serialize(serializer),
+            LedgerEntry::MPTokenIssuance(inner) => inner.serialize(serializer),
+            LedgerEntry::NegativeUNL(inner) => inner.serialize(serializer),
+            LedgerEntry::NFTokenOffer(inner) => inner.serialize(serializer),
+            LedgerEntry::NFTokenPage(inner) => inner.serialize(serializer),
+            LedgerEntry::Offer(inner) => inner.serialize(serializer),
+            LedgerEntry::Oracle(inner) => inner.serialize(serializer),
+            LedgerEntry::PayChannel(inner) => inner.serialize(serializer),
+            LedgerEntry::PermissionedDomain(inner) => inner.serialize(serializer),
+            LedgerEntry::RippleState(inner) => inner.serialize(serializer),
+            LedgerEntry::SignerList(inner) => inner.serialize(serializer),
+            LedgerEntry::Ticket(inner) => inner.serialize(serializer),
+            LedgerEntry::Vault(inner) => inner.serialize(serializer),
+            LedgerEntry::XChainOwnedClaimID(inner) => inner.serialize(serializer),
+            LedgerEntry::XChainOwnedCreateAccountClaimID(inner) => inner.serialize(serializer),
+        }
+    }
+}
+
+impl<'de, 'a> Deserialize<'de> for LedgerEntry<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        let ledger_entry_type = value
+            .get("LedgerEntryType")
+            .and_then(Value::as_str)
+            .ok_or_else(|| serde::de::Error::missing_field("LedgerEntryType"))?
+            .to_owned();
+
+        let result: serde_json::Result<Self> = match ledger_entry_type.as_str() {
+            "AccountRoot" => serde_json::from_value(value).map(LedgerEntry::AccountRoot),
+            "Amendments" => serde_json::from_value(value).map(LedgerEntry::Amendments),
+            "AMM" => serde_json::from_value(value).map(LedgerEntry::AMM),
+            "Bridge" => serde_json::from_value(value).map(LedgerEntry::Bridge),
+            "Check" => serde_json::from_value(value).map(LedgerEntry::Check),
+            "DID" => serde_json::from_value(value).map(LedgerEntry::DID),
+            "Credential" => serde_json::from_value(value).map(LedgerEntry::Credential),
+            "DepositPreauth" => serde_json::from_value(value).map(LedgerEntry::DepositPreauth),
+            "DirectoryNode" => serde_json::from_value(value).map(LedgerEntry::DirectoryNode),
+            "Escrow" => serde_json::from_value(value).map(LedgerEntry::Escrow),
+            "FeeSettings" => serde_json::from_value(value).map(LedgerEntry::FeeSettings),
+            "LedgerHashes" => serde_json::from_value(value).map(LedgerEntry::LedgerHashes),
+            "MPToken" => serde_json::from_value(value).map(LedgerEntry::MPToken),
+            "MPTokenIssuance" => serde_json::from_value(value).map(LedgerEntry::MPTokenIssuance),
+            "NegativeUNL" => serde_json::from_value(value).map(LedgerEntry::NegativeUNL),
+            "NFTokenOffer" => serde_json::from_value(value).map(LedgerEntry::NFTokenOffer),
+            "NFTokenPage" => serde_json::from_value(value).map(LedgerEntry::NFTokenPage),
+            "Offer" => serde_json::from_value(value).map(LedgerEntry::Offer),
+            "Oracle" => serde_json::from_value(value).map(LedgerEntry::Oracle),
+            "PayChannel" => serde_json::from_value(value).map(LedgerEntry::PayChannel),
+            "PermissionedDomain" => {
+                serde_json::from_value(value).map(LedgerEntry::PermissionedDomain)
+            }
+            "RippleState" => serde_json::from_value(value).map(LedgerEntry::RippleState),
+            "SignerList" => serde_json::from_value(value).map(LedgerEntry::SignerList),
+            "Ticket" => serde_json::from_value(value).map(LedgerEntry::Ticket),
+            "Vault" => serde_json::from_value(value).map(LedgerEntry::Vault),
+            "XChainOwnedClaimID" => {
+                serde_json::from_value(value).map(LedgerEntry::XChainOwnedClaimID)
+            }
+            "XChainOwnedCreateAccountClaimID" => {
+                serde_json::from_value(value).map(LedgerEntry::XChainOwnedCreateAccountClaimID)
+            }
+            other => Err(<serde_json::Error as serde::de::Error>::unknown_variant(
+                other,
+                LEDGER_ENTRY_TYPE_VARIANTS,
+            )),
+        };
+
+        result.map_err(serde::de::Error::custom)
+    }
 }
 
 #[skip_serializing_none]
@@ -243,9 +375,55 @@ mod tests {
         );
         let entry = LedgerEntry::Bridge(bridge);
         let serialized = serde_json::to_string(&entry).unwrap();
-        // The enum is untagged-ish; default behaviour is externally tagged on
-        // variant name. Either way, round-trip must work for the same JSON.
+        // Serialize/Deserialize are hand-written to match the flat XRPL wire
+        // format (tagged via an inline `LedgerEntryType` field), not serde's
+        // default externally-tagged `{"Bridge": {...}}`.
+        assert!(!serialized.starts_with("{\"Bridge\":"));
         let deserialized: LedgerEntry = serde_json::from_str(&serialized).unwrap();
         assert_eq!(entry, deserialized);
+    }
+
+    #[test]
+    fn test_ledger_entry_enum_deserializes_flat_wire_format() {
+        // Real rippled `ledger_entry`/`ledger` output: a flat object with an
+        // inline `LedgerEntryType` discriminator, no externally-tagged wrapper.
+        // Covers a non-AccountRoot entry, since that's the shape that used to
+        // fail before `node` was widened past a hardcoded AccountRoot struct.
+        let json = r#"{
+            "Flags": 0,
+            "Indexes": ["AAB0000000000000000000000000000000000000000000000000000000000"],
+            "IndexNext": 1,
+            "IndexPrevious": 0,
+            "LedgerEntryType": "DirectoryNode",
+            "Owner": "rN7n3473SaZBCG4dFL83w7p1W9cgPLAPkS",
+            "RootIndex": "A832B09498B80B1B1BB0E2B31B41B8A3A4B57B8C1C23DAF43A76C6B1B3F7CD60",
+            "index": "A832B09498B80B1B1BB0E2B31B41B8A3A4B57B8C1C23DAF43A76C6B1B3F7CD60"
+        }"#;
+
+        let entry: LedgerEntry = serde_json::from_str(json).unwrap();
+        match entry {
+            LedgerEntry::DirectoryNode(directory_node) => {
+                assert_eq!(
+                    directory_node.owner.as_deref(),
+                    Some("rN7n3473SaZBCG4dFL83w7p1W9cgPLAPkS")
+                );
+                assert_eq!(directory_node.index_next, Some(1));
+            }
+            other => panic!("expected DirectoryNode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_ledger_entry_enum_rejects_unknown_ledger_entry_type() {
+        let json = r#"{"LedgerEntryType": "NotARealType", "index": "AABB"}"#;
+        let err = serde_json::from_str::<LedgerEntry>(json).unwrap_err();
+        assert!(err.to_string().contains("NotARealType"));
+    }
+
+    #[test]
+    fn test_ledger_entry_enum_missing_ledger_entry_type() {
+        let json = r#"{"index": "AABB"}"#;
+        let err = serde_json::from_str::<LedgerEntry>(json).unwrap_err();
+        assert!(err.to_string().contains("LedgerEntryType"));
     }
 }

--- a/src/models/results/ledger_entry.rs
+++ b/src/models/results/ledger_entry.rs
@@ -1,7 +1,8 @@
 use alloc::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+
+use crate::models::ledger::objects::LedgerEntry as LedgerObject;
 
 /// Response format for the ledger_entry method, which returns a single ledger
 /// object from the XRP Ledger in its raw format.
@@ -17,11 +18,9 @@ pub struct LedgerEntry<'a> {
     pub ledger_index: Option<u32>,
     /// The identifying hash of the ledger version used to retrieve this data
     pub ledger_hash: Option<Cow<'a, str>>,
-    /// Object containing the data of this ledger entry, according to the
-    /// ledger format. Omitted if "binary": true specified.
-    /// This is a generic JSON value because `ledger_entry` can return any
-    /// ledger object type (AccountRoot, DirectoryNode, Offer, etc.).
-    pub node: Option<Value>,
+    /// The data of this ledger entry, typed according to its `LedgerEntryType`.
+    /// Omitted if "binary": true specified.
+    pub node: Option<LedgerObject<'a>>,
     /// The binary representation of the ledger object, as hexadecimal.
     /// Only present if "binary": true specified.
     pub node_binary: Option<Cow<'a, str>>,
@@ -75,53 +74,78 @@ mod tests {
         );
         assert_eq!(result.validated, Some(true));
 
-        let node = result.node.unwrap();
-        assert_eq!(node["Account"], "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
-        assert_eq!(
-            node["AccountTxnID"],
-            "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB"
-        );
-        assert_eq!(node["Balance"], "424021949");
-        assert_eq!(node["Domain"], "6D64756F31332E636F6D");
-        assert_eq!(node["EmailHash"], "98B4375E1D753E5B91627516F6D70977");
-        assert_eq!(node["Flags"], 9568256);
-        assert_eq!(node["LedgerEntryType"], "AccountRoot");
-        assert_eq!(node["MessageKey"], "0000000000000000000000070000000300");
-        assert_eq!(node["OwnerCount"], 12);
-        assert_eq!(
-            node["PreviousTxnID"],
-            "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB"
-        );
-        assert_eq!(node["PreviousTxnLgrSeq"], 61965653);
-        assert_eq!(node["RegularKey"], "rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ");
-        assert_eq!(node["Sequence"], 385);
-        assert_eq!(node["TransferRate"], 4294967295u64);
-        assert_eq!(
-            node["index"],
-            "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
-        );
+        match result.node.unwrap() {
+            LedgerObject::AccountRoot(account_root) => {
+                assert_eq!(account_root.account, "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+                assert_eq!(
+                    account_root.account_txn_id.as_deref(),
+                    Some("4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB")
+                );
+                assert_eq!(account_root.balance.unwrap().0, "424021949");
+                assert_eq!(account_root.domain.as_deref(), Some("6D64756F31332E636F6D"));
+                assert_eq!(
+                    account_root.email_hash.as_deref(),
+                    Some("98B4375E1D753E5B91627516F6D70977")
+                );
+                assert_eq!(
+                    account_root.message_key.as_deref(),
+                    Some("0000000000000000000000070000000300")
+                );
+                assert_eq!(account_root.owner_count, 12);
+                assert_eq!(
+                    account_root.previous_txn_id,
+                    "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB"
+                );
+                assert_eq!(account_root.previous_txn_lgr_seq, 61965653);
+                assert_eq!(
+                    account_root.regular_key.as_deref(),
+                    Some("rD9iJmieYHn8jTtPjwwkW2Wm9sVDvPXLoJ")
+                );
+                assert_eq!(account_root.sequence, 385);
+                assert_eq!(account_root.transfer_rate, Some(4294967295));
+            }
+            other => panic!("expected AccountRoot, got {other:?}"),
+        }
     }
 
     #[test]
     fn test_ledger_entry_round_trip() {
+        use crate::models::amount::XRPAmount;
+        use crate::models::ledger::objects::account_root::AccountRoot;
+        use crate::models::FlagCollection;
+
+        let account_root = AccountRoot::new(
+            FlagCollection::default(),
+            Some("13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8".into()),
+            None,
+            "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn".into(),
+            12,
+            "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB".into(),
+            61965653,
+            385,
+            None,
+            Some(XRPAmount::from("424021949")),
+            None,
+            Some("6D64756F31332E636F6D".into()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
         let entry = LedgerEntry {
             index: "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8".into(),
             ledger_index: Some(61966146),
             ledger_hash: Some(
                 "31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726".into(),
             ),
-            node: Some(serde_json::json!({
-                "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                "Balance": "424021949",
-                "Domain": "6D64756F31332E636F6D",
-                "Flags": 9568256,
-                "LedgerEntryType": "AccountRoot",
-                "OwnerCount": 12,
-                "PreviousTxnID": "4E0AA11CBDD1760DE95B68DF2ABBE75C9698CEB548BEA9789053FCB3EBD444FB",
-                "PreviousTxnLgrSeq": 61965653,
-                "Sequence": 385,
-                "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
-            })),
+            node: Some(LedgerObject::AccountRoot(account_root)),
             node_binary: None,
             deleted_ledger_index: None,
             validated: Some(true),
@@ -155,14 +179,16 @@ mod tests {
 
     #[test]
     fn test_ledger_entry_directory_node() {
+        // Non-AccountRoot entry: this is the shape that used to fail before
+        // `node` was widened past a hardcoded AccountRoot-only struct (#308).
         let json = r#"{
             "index": "A832B09498B80B1B1BB0E2B31B41B8A3A4B57B8C1C23DAF43A76C6B1B3F7CD60",
             "ledger_index": 100,
             "node": {
                 "Flags": 0,
-                "Indexes": ["AAB..."],
-                "IndexNext": "0",
-                "IndexPrevious": "0",
+                "Indexes": ["AAB0000000000000000000000000000000000000000000000000000000000"],
+                "IndexNext": 0,
+                "IndexPrevious": 0,
                 "LedgerEntryType": "DirectoryNode",
                 "Owner": "rN7n3473SaZBCG4dFL83w7p1W9cgPLAPkS",
                 "RootIndex": "A832B09498B80B1B1BB0E2B31B41B8A3A4B57B8C1C23DAF43A76C6B1B3F7CD60",
@@ -172,8 +198,18 @@ mod tests {
         }"#;
 
         let result: LedgerEntry = serde_json::from_str(json).unwrap();
-        let node = result.node.unwrap();
-        assert_eq!(node["LedgerEntryType"], "DirectoryNode");
-        assert_eq!(node["Owner"], "rN7n3473SaZBCG4dFL83w7p1W9cgPLAPkS");
+        match result.node.unwrap() {
+            LedgerObject::DirectoryNode(directory_node) => {
+                assert_eq!(
+                    directory_node.owner.as_deref(),
+                    Some("rN7n3473SaZBCG4dFL83w7p1W9cgPLAPkS")
+                );
+                assert_eq!(
+                    directory_node.root_index,
+                    "A832B09498B80B1B1BB0E2B31B41B8A3A4B57B8C1C23DAF43A76C6B1B3F7CD60"
+                );
+            }
+            other => panic!("expected DirectoryNode, got {other:?}"),
+        }
     }
 }

--- a/tests/requests/ledger_entry.rs
+++ b/tests/requests/ledger_entry.rs
@@ -10,6 +10,7 @@ use crate::common::{
 };
 use xrpl::asynch::clients::XRPLAsyncClient;
 use xrpl::models::{
+    ledger::objects::{credential::CredentialFlag, LedgerEntry as LedgerObject},
     requests::{
         ledger_data::LedgerData as LedgerDataRequest,
         ledger_entry::{Credential as CredentialSelector, LedgerEntry, VaultIdentifier},
@@ -72,8 +73,6 @@ async fn test_ledger_entry_base() {
 
 // ── credential: provision a Credential then fetch it via ledger_entry selector ─
 
-const LSF_ACCEPTED: u64 = 0x00010000;
-
 #[tokio::test]
 async fn test_ledger_entry_credential() {
     with_blockchain_lock(|| async {
@@ -106,11 +105,16 @@ async fn test_ledger_entry_credential() {
         let node = entry_result
             .node
             .expect("node should be present after CredentialAccept");
-        let flags = node["Flags"].as_u64().expect("Flags field missing");
-        assert!(
-            flags & LSF_ACCEPTED != 0,
-            "lsfAccepted should be set after CredentialAccept, got Flags={flags:#010x}"
-        );
+        match node {
+            LedgerObject::Credential(credential) => {
+                let mut flags = credential.common_fields.flags;
+                assert!(
+                    flags.any(|flag| flag == CredentialFlag::LsfAccepted),
+                    "lsfAccepted should be set after CredentialAccept"
+                );
+            }
+            other => panic!("expected Credential, got {other:?}"),
+        }
     })
     .await;
 }
@@ -161,10 +165,8 @@ async fn test_ledger_entry_vault_by_id() {
             entry_result.node.is_some(),
             "node should be present in ledger_entry response"
         );
-        let node = entry_result.node.unwrap();
-        assert_eq!(
-            node["LedgerEntryType"].as_str(),
-            Some("Vault"),
+        assert!(
+            matches!(entry_result.node.unwrap(), LedgerObject::Vault(_)),
             "expected LedgerEntryType Vault"
         );
         assert_eq!(


### PR DESCRIPTION
## High Level Overview of Change

Types the `ledger_entry` result's `node` field using the existing `LedgerEntry` enum from `models::ledger::objects`, replacing the untyped `Option<serde_json::Value>`.

```rust
// before
pub node: Option<serde_json::Value>,
// after
pub node: Option<crate::models::ledger::objects::LedgerEntry<'a>>,
```

Since the `models::ledger::objects::LedgerEntry` enum already existed (used by `Ledger::account_state` for full-ledger state dumps), this reuses it rather than introducing a second, parallel discriminated-union type — one enum, two call sites.

### Blockers noted in #308

The issue calls out that the real obstacle is XRPL's wire format: a flat object carrying its own `LedgerEntryType` discriminator (`{"LedgerEntryType": "AccountRoot", "Account": ..., ...}`), which doesn't fit serde's default externally-tagged enum representation, and doesn't fit `#[serde(tag = "LedgerEntryType")]` either without removing `ledger_entry_type` from `CommonFields` (a breaking change across every ledger object struct). This implements the issue's suggested workaround: a hand-written `Deserialize` for `LedgerEntry` that buffers to `serde_json::Value`, reads `LedgerEntryType` to pick the variant, then delegates to `serde_json::from_value` for that variant's own `Deserialize`. `Serialize` is likewise hand-written to flatten straight through to the inner type instead of wrapping it — the enum's default derive was serializing as `{"AccountRoot": {...}}`, which doesn't match real rippled output either, and was already silently wrong for `Ledger::account_state` before this change (nothing previously exercised that path with real wire-format JSON).

Unknown/unrecognized `LedgerEntryType` values are a deserialize error (`unknown_variant`) rather than silently dropped, so a future ledger object type rippled adds before this crate models it fails loudly instead of losing data.

### Context of Change

Filed as #308. Overlaps in idea with the `node` typing included in #160 (open since April, part of a much larger integration-tests PR) — this is a standalone implementation of just that piece, reusing the existing `LedgerEntry` enum instead of #160's parallel `LedgerEntryNode` type, so it doesn't carry a duplicate 26-variant definition and doesn't need an `Unknown(Value)` catch-all. Flagging the overlap here so it's easy to reconcile with #160 either way.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests

## Before / After

Deserializing a non-`AccountRoot` entry — the exact scenario #308 says used to fail before `node` was widened past a hardcoded `AccountRoot` struct — now dispatches correctly:

```rust
let entry: LedgerEntry = serde_json::from_str(r#"{
    "LedgerEntryType": "DirectoryNode",
    "Owner": "rN7n...",
    ...
}"#)?;
match entry.node.unwrap() {
    LedgerEntry::DirectoryNode(directory_node) => { /* typed access */ }
    _ => unreachable!(),
}
```

`Ledger::account_state` (the other consumer of `models::ledger::objects::LedgerEntry`) now round-trips against the real flat wire format too, as a side effect of fixing `Serialize`/`Deserialize` on the shared enum.

## Test Plan

- `cargo test --release`: 1316 passed (up from 1313 on `main`).
- Added to `models::ledger::objects`: a flat-wire-format deserialize test for a non-`AccountRoot` entry (`DirectoryNode`), an unknown-`LedgerEntryType` rejection test, and a missing-`LedgerEntryType` rejection test. Tightened the existing round-trip test to assert the wire format is no longer externally-tagged.
- Rewrote `models::results::ledger_entry`'s existing tests (deserialize, round-trip, `DirectoryNode`) to pattern-match the typed enum instead of indexing into `serde_json::Value`.
- Updated the two integration tests in `tests/requests/ledger_entry.rs` that inspected `node` as raw JSON (`credential`, `vault_by_id`) to match on the typed variant instead — compiled clean under `cargo check --tests --features std,json-rpc,helpers,cli,websocket,integration` (these need a live `xrpld` node to actually execute, so compiled but not run end-to-end here).
- `cargo clippy --all-targets --features std,json-rpc,helpers,cli,websocket,integration` and `cargo fmt --check`: clean on all changed files.

Closes #308
